### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/src/libs/rally/rallyServices.ts
+++ b/src/libs/rally/rallyServices.ts
@@ -221,6 +221,26 @@ function buildUserStoryQuery(query: RallyQuery) {
 	return rallyQueries.length ? rallyQueries.reduce((a: RallyQueryBuilder, b: RallyQueryBuilder) => a.and(b)) : null;
 }
 
+// Helper function to safely sanitize HTML descriptions
+function sanitizeDescription(description: unknown) {
+	if (typeof description !== 'string') {
+		return description;
+	}
+
+	let sanitized = description;
+	let previous: string;
+	// Repeatedly remove HTML-like tags to avoid incomplete multi-character sanitization
+	do {
+		previous = sanitized;
+		sanitized = sanitized.replace(/<[^>]*>/g, '');
+	} while (sanitized !== previous);
+
+	// Remove any remaining angle brackets to avoid HTML element injection
+	sanitized = sanitized.replace(/[<>]/g, '');
+
+	return sanitized;
+}
+
 // Helper function to format user stories
 function formatUserStories(result: RallyApiResult): RallyUserStory[] {
 	// biome-ignore lint/suspicious/noExplicitAny: Rally API has dynamic structure
@@ -228,7 +248,7 @@ function formatUserStories(result: RallyApiResult): RallyUserStory[] {
 		objectId: userStory.objectId,
 		formattedId: userStory.formattedId,
 		name: userStory.name,
-		description: typeof userStory.description === 'string' ? userStory.description.replace(/<[^>]*>/g, '') : userStory.description,
+		description: sanitizeDescription(userStory.description),
 		state: userStory.state,
 		planEstimate: userStory.planEstimate,
 		toDo: userStory.toDo,


### PR DESCRIPTION
Potential fix for [https://github.com/trevSmart/robert/security/code-scanning/6](https://github.com/trevSmart/robert/security/code-scanning/6)

In general, the problem is that manually stripping HTML with a regex like `/\<[^>]*\>/g` is brittle and can leave dangerous fragments, including patterns like `<script`, due to incomplete multi-character sanitization. A safer approach is to use a robust HTML sanitization/parsing library, or at least a strategy that repeatedly removes tags until none remain and then escapes or neutralizes any remaining `<`/`>` characters.

The best minimal-impact fix here is to change the sanitization so that it (1) removes any HTML-like tags robustly, and (2) ensures no raw `<` or `>` remain in the returned description string. Because you must not assume project-specific helpers, a small self-contained helper function can be added in this file to sanitize descriptions: it will coerce to string, repeatedly remove tags using a reasonably strict pattern, and finally replace any remaining `<` and `>` characters. This preserves the existing behavior of returning plain text (no HTML), while closing the multi-character sanitization gap that CodeQL warns about.

Concretely:
- In `src/libs/rally/rallyServices.ts`, define a new internal function, e.g. `sanitizeDescription`, near the bottom of the file (before or after `formatUserStories`), which:
  - Accepts `unknown` or `string | null | undefined`.
  - If the argument is not a string, returns it as-is (to keep behavior consistent).
  - Otherwise:
    - Repeatedly strips tags:  
      `let previous; do { previous = value; value = value.replace(/<[^>]*>/g, ''); } while (value !== previous);`
    - Then replaces any remaining `<` or `>` with empty string: `value = value.replace(/[<>]/g, '');`
    - Returns the sanitized string.
- Update line 231 to call this helper instead of inlining `description.replace(/<[^>]*>/g, '')`.

No new external imports are required; we can perform this using built-in string methods and regex. Functionality from a caller perspective remains “return description as plain text without HTML tags,” but is now more robust against multi-character sanitization issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
