### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/src/templates/mainWebview.html
+++ b/src/templates/mainWebview.html
@@ -460,12 +460,16 @@
                         errorDiv.innerHTML = `
                             <div style="color: var(--vscode-errorForeground); padding: 16px; text-align: center;">
                                 <h3>Configuration Required</h3>
-                                <p>${message.error}</p>
+                                <p id="projectsErrorMessage"></p>
                                 <button onclick="openSettings()" style="margin-top: 8px; padding: 8px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 4px; cursor: pointer;">
                                     Open Settings
                                 </button>
                             </div>
                         `;
+                        const errorMessageEl = document.getElementById('projectsErrorMessage');
+                        if (errorMessageEl && typeof message.error === 'string') {
+                            errorMessageEl.textContent = message.error;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Potential fix for [https://github.com/trevSmart/robert/security/code-scanning/2](https://github.com/trevSmart/robert/security/code-scanning/2)

In general, the fix is to avoid inserting untrusted data into the DOM using `innerHTML` (or similarly dangerous sinks) without proper escaping. Instead, create DOM elements and assign untrusted content via `textContent`/`innerText`, or escape/encode the string before using `innerHTML`.

For this specific case, the only untrusted part of the HTML snippet is `message.error`. The surrounding structure is static and safe. The minimally invasive and functionally equivalent fix is:

- Stop embedding `${message.error}` into the template that is assigned to `errorDiv.innerHTML`.
- Instead, set the static HTML structure (with a placeholder element for the error message) via `innerHTML`.
- Then locate that placeholder element and set its `textContent` to `message.error`, ensuring any HTML tags/scripts in the error string are rendered harmless as text.

Concretely, in `src/templates/mainWebview.html` around lines 460–468, replace the single `innerHTML = \`...\`` block with:
- An `innerHTML` assignment that uses a `<p id="projectsErrorMessage"></p>` (or similar) without interpolating `message.error`.
- Then, if `message.error` is defined, set `document.getElementById('projectsErrorMessage').textContent = message.error;`.

No additional libraries or imports are needed; the fix uses standard DOM APIs only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
