### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/src/libs/rally/rallyServices.ts
+++ b/src/libs/rally/rallyServices.ts
@@ -2,6 +2,15 @@ import { rallyData } from '../../extension.js';
 import type { RallyApiObject, RallyApiResult, RallyProject, RallyQuery, RallyQueryBuilder, RallyQueryOptions, RallyUser, RallyUserStory } from '../../types/rally';
 import { getRallyApi, queryUtils, validateRallyConfiguration } from './utils';
 
+function escapeHtml(input: string): string {
+	return input
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
 export async function getProjects(query: Record<string, unknown> = {}, limit: number | null = null) {
 	// Validem la configuració de Rally abans de fer la crida
 	const validation = await validateRallyConfiguration();
@@ -73,7 +82,7 @@ export async function getProjects(query: Record<string, unknown> = {}, limit: nu
 	const projects: RallyProject[] = resultData.Results.map((project: RallyApiObject) => ({
 		objectId: project.objectId,
 		name: project.name,
-		description: typeof project.description === 'string' ? project.description.replace(/<[^>]*>/g, '') : project.description,
+		description: typeof project.description === 'string' ? escapeHtml(project.description) : project.description,
 		state: project.state,
 		creationDate: project.creationDate,
 		lastUpdateDate: project.lastUpdateDate,


### PR DESCRIPTION
Potential fix for [https://github.com/trevSmart/robert/security/code-scanning/5](https://github.com/trevSmart/robert/security/code-scanning/5)

In general, the problem should be fixed by avoiding ad‑hoc regex-based stripping of HTML and instead either (1) properly escape HTML special characters (`<`, `>`, `&`, `"`, `'`) so the description is always treated as text, or (2) use a well-tested HTML sanitization library that removes dangerous elements and attributes. Both approaches avoid the multi-character regex pitfalls highlighted by CodeQL.

The best fix here, without changing the observable behavior too much, is to replace the current regex-based tag stripper with a small, explicit HTML-escaping helper that turns any `<`/`>` (and other special chars) into entities. The existing code intends to present a text-only description (it strips all tags), so returning an HTML-escaped string is consistent with that intent and safer: any existing tags or partial `<script` fragments will be rendered harmlessly as text. We can implement a simple `escapeHtml` function locally in this file, use it only when `project.description` is a string, and leave non-string descriptions unchanged as now. No external dependencies are necessary.

Concretely:
- In `src/libs/rally/rallyServices.ts`, add a small `escapeHtml` helper near the top of the file.
- Change line 76 so that instead of `project.description.replace(/<[^>]*>/g, '')`, it calls `escapeHtml(project.description)`.
- Keep the rest of the mapping logic intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
