### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,6 +277,7 @@
 		"react-dom": "^19.2.3",
 		"styled-components": "^6.1.19",
 		"vite": "^7.3.0",
-		"vscrui": "^0.3.0"
+		"vscrui": "^0.3.0",
+		"striptags": "^3.2.0"
 	}
 }

--- a/src/libs/rally/rallyServices copy.js
+++ b/src/libs/rally/rallyServices copy.js
@@ -1,5 +1,6 @@
 import { rallyData } from '../../extension.js';
 import { getRallyApi, queryUtils } from './utils.js';
+import striptags from 'striptags';
 
 export async function getProjects(query = {}, limit = null) {
 	const rallyApi = getRallyApi();
@@ -218,7 +219,7 @@ function formatUserStories(result) {
 		objectId: userStory.objectId,
 		formattedId: userStory.formattedId,
 		name: userStory.name,
-		description: typeof userStory.description === 'string' ? userStory.description.replace(/<[^>]*>/g, '') : userStory.description,
+		description: typeof userStory.description === 'string' ? striptags(userStory.description) : userStory.description,
 		state: userStory.state,
 		planEstimate: userStory.planEstimate,
 		toDo: userStory.toDo,


### PR DESCRIPTION
Potential fix for [https://github.com/trevSmart/robert/security/code-scanning/4](https://github.com/trevSmart/robert/security/code-scanning/4)

In general, the best fix is to stop using a hand‑rolled HTML‑stripping regex and instead use a well‑tested HTML sanitization/stripping library. That avoids incomplete multi‑character sanitization issues and many edge cases (nested/malformed tags, special elements, attributes).

For this specific code, the intent appears to be to show the description as plain text (tags removed). A good solution is:

1. Add an import for a small, well‑known library that converts HTML to text safely, e.g. `striptags` from npm.
2. Replace `userStory.description.replace(/<[^>]*>/g, '')` with a function that uses `striptags` to remove all HTML, returning `null`/the original value when `description` is not a string.

This keeps behavior (strip HTML tags) but does it robustly and eliminates the risk flagged by CodeQL. All changes are localized to `src/libs/rally/rallyServices copy.js`: one import line and one replacement in the `formatUserStories` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
