### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/src/libs/rally/rallyServices copy.js
+++ b/src/libs/rally/rallyServices copy.js
@@ -66,7 +66,7 @@ export async function getProjects(query = {}, limit = null) {
 	const projects = result.results.map((project) => ({
 		objectId: project.objectId,
 		name: project.name,
-		description: typeof project.description === 'string' ? project.description.replace(/<[^>]*>/g, '') : project.description,
+		description: typeof project.description === 'string' ? striptags(project.description) : project.description,
 		state: project.state,
 		creationDate: project.creationDate,
 		lastUpdateDate: project.lastUpdateDate,


### PR DESCRIPTION
Potential fix for [https://github.com/trevSmart/robert/security/code-scanning/3](https://github.com/trevSmart/robert/security/code-scanning/3)

In general, the best way to fix incomplete multi‑character sanitization is to avoid ad‑hoc regexes for HTML stripping and instead use a well‑tested, purpose‑built library. In this file, `striptags` is already imported and is designed exactly for turning HTML strings into plain text safely.

Concretely, we should replace the use of `.replace(/<[^>]*>/g, '')` with a call to `striptags(project.description)`. This keeps the existing behavior—returning a string with tags removed—but delegates the complexity to the library, which better handles malformed HTML, nested tags, and edge cases that can lead to residual `<script` substrings. The change is localized to the mapping of `result.results` into `projects`, specifically the ternary that sets `description` on line 69; imports and other logic remain untouched.

Implementation details:

- We already have `import striptags from 'striptags';` at the top of `src/libs/rally/rallyServices copy.js`, so no new imports are required.
- Update line 69 so that when `project.description` is a string, we call `striptags(project.description)` instead of using `.replace(/<[^>]*>/g, '')`.
- Preserve the behavior for non‑string `project.description` values by keeping the ternary structure unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
