### PR TITLE
chore(deps): bump the npm_and_yarn group across 1 directory with 3 updates (#208)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "robert",
-	"version": "0.3.3",
+	"version": "0.3.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "robert",
-			"version": "0.3.3",
+			"version": "0.3.5",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",
 				"dompurify": "^3.4.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "robert",
 	"displayName": "IBM Robert",
 	"description": "For IBM internal use only.",
-	"version": "0.3.3",
+	"version": "0.3.5",
 	"type": "commonjs",
 	"icon": "resources/icons/robert-logo.png",
 	"publisher": "trevSmart",

--- a/src/RobertWebviewProvider.ts
+++ b/src/RobertWebviewProvider.ts
@@ -18,6 +18,9 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 	private _disposables: vscode.Disposable[] = [];
 	private _currentPanel: vscode.WebviewPanel | undefined;
 	private _currentView?: vscode.WebviewView;
+	// Message listener currently bound to the activity bar view (intro screen or
+	// main UI). Disposed before binding a new one so reloads don't stack handlers.
+	private _viewMessageListener?: vscode.Disposable;
 	private _errorHandler: ErrorHandler;
 	private _settingsManager: SettingsManager;
 	private _collaborationClient: CollaborationClient;
@@ -317,7 +320,11 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 		const preloadedData = this._preloadedData;
 		webviewView.webview.html = await this._getHtmlForWebview(webviewView.webview, 'activity-bar', webviewId, preloadedData);
 		this._preloadedData = undefined;
-		this._setWebviewMessageListener(webviewView.webview, webviewId);
+		// Dispose any prior listener bound to this view (a previous render or the
+		// intro screen) so reloads don't stack duplicate message handlers, which
+		// would otherwise cause duplicate Rally calls and "Unknown command" warnings.
+		this._viewMessageListener?.dispose();
+		this._viewMessageListener = this._setWebviewMessageListener(webviewView.webview, webviewId);
 		this._postDevModeInit(webviewView.webview);
 	}
 
@@ -344,6 +351,9 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 			await this._renderMainView(webviewView);
 		};
 
+		// Dispose any listener still bound to this view from a previous render
+		// (e.g. the main UI listener after a reload) before attaching the intro one.
+		this._viewMessageListener?.dispose();
 		const subscription = webviewView.webview.onDidReceiveMessage(async message => {
 			await this._errorHandler.executeWithErrorHandling(async () => {
 				switch (message?.command) {
@@ -365,6 +375,8 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 				}
 			}, 'RobertWebviewProvider._showIntroVideoInView');
 		});
+		// Track the intro listener so a subsequent render/reload can dispose it.
+		this._viewMessageListener = subscription;
 		this._disposables.push(subscription);
 	}
 
@@ -685,9 +697,9 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 		);
 	}
 
-	private _setWebviewMessageListener(webview: vscode.Webview, webviewId?: string) {
+	private _setWebviewMessageListener(webview: vscode.Webview, webviewId?: string): vscode.Disposable {
 		this._errorHandler.logInfo(`Setting up message listener for webview: ${webviewId || 'unknown'}`, 'WebviewMessageListener');
-		webview.onDidReceiveMessage(
+		const listener = webview.onDidReceiveMessage(
 			async message => {
 				await this._errorHandler.executeWithErrorHandling(async () => {
 					const handled = await this._messageDispatcher.dispatch(message.command, webview, message);
@@ -707,6 +719,7 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 			undefined,
 			this._disposables
 		);
+		return listener;
 	}
 
 	/**

--- a/src/webview/WebviewContentManager.ts
+++ b/src/webview/WebviewContentManager.ts
@@ -61,10 +61,10 @@ export class WebviewContentManager {
 				const videoUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'resources', 'video.mp4'));
 				const bridgeUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'webview-bridge.js'));
 				return fs
-						.readFileSync(path.join(this.extensionUri.fsPath, 'src', 'webview', 'loading.html'), 'utf8')
-						.replace('__VIDEO_URI__', videoUri.toString())
-						.replace('__BRIDGE_URI__', bridgeUri.toString())
-						.replace('__CSP_META__', this.buildCspMeta(webview));
+					.readFileSync(path.join(this.extensionUri.fsPath, 'src', 'webview', 'loading.html'), 'utf8')
+					.replace('__VIDEO_URI__', videoUri.toString())
+					.replace('__BRIDGE_URI__', bridgeUri.toString())
+					.replace('__CSP_META__', this.buildCspMeta(webview));
 			}, 'WebviewContentManager.getHtmlForLoading')) || '<html><body><p>Error loading loading screen</p></body></html>'
 		);
 	}
@@ -118,6 +118,9 @@ export class WebviewContentManager {
 			const uri = toWebviewUri(value.replace(/^\//, ''));
 			return `${attr}="${uri}"`;
 		});
+
+		// VS Code webviews cannot load crossorigin module scripts from vscode-webview:// URIs.
+		html = html.replace(/\s+crossorigin(="[^"]*")?/g, '');
 
 		const cspMeta = this.buildCspMeta(webview);
 		const bridgeUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'webview-bridge.js'));

--- a/src/webview/components/MainWebview.tsx
+++ b/src/webview/components/MainWebview.tsx
@@ -520,9 +520,7 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 	const preloadedData = typeof window !== 'undefined' ? window.__robertPreloadedData : undefined;
 	const hasPreloadedData = Boolean(preloadedData && Array.isArray(preloadedData.iterations) && preloadedData.iterations.length > 0);
 
-	const [iterations, setIterations] = useState<Iteration[]>(
-		hasPreloadedData ? (preloadedData.iterations as Iteration[]) : []
-	);
+	const [iterations, setIterations] = useState<Iteration[]>(hasPreloadedData ? (preloadedData.iterations as Iteration[]) : []);
 	const [iterationsLoading, setIterationsLoading] = useState(!hasPreloadedData);
 	const [iterationsError, setIterationsError] = useState<string | null>(null);
 	const [selectedIteration, setSelectedIteration] = useState<Iteration | null>(null);

--- a/src/webview/loading.html
+++ b/src/webview/loading.html
@@ -74,11 +74,18 @@
 
 	<script>
 		(function () {
-			var vscode = null;
-			try {
-				vscode = acquireVsCodeApi();
-			} catch (e) {
-				vscode = null;
+			// webview-bridge.js (injected in <head>) already calls acquireVsCodeApi once.
+			// A second call throws, so reuse the bridge instance instead of acquiring again.
+			var vscode = window.__vscodeApi || null;
+			if (!vscode) {
+				try {
+					vscode = typeof acquireVsCodeApi === 'function' ? acquireVsCodeApi() : null;
+					if (vscode) {
+						window.__vscodeApi = vscode;
+					}
+				} catch (e) {
+					vscode = null;
+				}
 			}
 
 			function post(message) {


### PR DESCRIPTION
Bumps the npm_and_yarn group with 3 updates in the /server directory: [ws](https://github.com/websockets/ws), [uuid](https://github.com/uuidjs/uuid) and [qs](https://github.com/ljharb/qs).


Updates `ws` from 8.19.0 to 8.20.1
- [Release notes](https://github.com/websockets/ws/releases)
- [Commits](https://github.com/websockets/ws/compare/8.19.0...8.20.1)

Updates `uuid` from 9.0.1 to 14.0.0
- [Release notes](https://github.com/uuidjs/uuid/releases)
- [Changelog](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md)
- [Commits](https://github.com/uuidjs/uuid/compare/v9.0.1...v14.0.0)

Updates `qs` from 6.14.2 to 6.15.2
- [Changelog](https://github.com/ljharb/qs/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ljharb/qs/compare/v6.14.2...v6.15.2)

---
updated-dependencies:
- dependency-name: ws
  dependency-version: 8.20.1
  dependency-type: direct:production
  dependency-group: npm_and_yarn
- dependency-name: uuid
  dependency-version: 14.0.0
  dependency-type: direct:production
  dependency-group: npm_and_yarn
- dependency-name: qs
  dependency-version: 6.15.2
  dependency-type: indirect
  dependency-group: npm_and_yarn
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>