### PR TITLE
fix: load complete sprint user stories for assignee hours

### DIFF
--- a/src/libs/rally/rallyServices.test.ts
+++ b/src/libs/rally/rallyServices.test.ts
@@ -1,13 +1,33 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { rallyData, queryBuilder } = vi.hoisted(() => {
+	const queryBuilder = {
+		and: vi.fn(function (this: unknown) {
+			return this;
+		})
+	};
+	const rallyData = {
+		userStories: [] as any[],
+		projects: [] as any[],
+		iterations: [] as any[],
+		tasks: [] as any[],
+		defects: [] as any[],
+		users: [] as any[],
+		currentUser: null as any
+	};
+	return { rallyData, queryBuilder };
+});
 
 // Mock vscode i extension per evitar efectes secundaris en importar rallyServices
 vi.mock('vscode', () => ({ default: {}, workspace: {}, window: {}, commands: {}, Uri: {} }));
-vi.mock('../../extension.js', () => ({ rallyData: {} }));
+vi.mock('../../extension.js', () => ({ rallyData }));
 vi.mock('./utils', () => ({
-	getRallyApi: vi.fn(),
-	queryUtils: {},
-	validateRallyConfiguration: vi.fn(),
-	getProjectId: vi.fn(),
+	getRallyApi: vi.fn(() => ({})),
+	queryUtils: {
+		where: vi.fn(() => queryBuilder)
+	},
+	validateRallyConfiguration: vi.fn(async () => ({ isValid: true, errors: [] })),
+	getProjectId: vi.fn(async () => '74278607305'),
 	clearUtilsCaches: vi.fn()
 }));
 vi.mock('./rallyCall', () => ({
@@ -17,7 +37,13 @@ vi.mock('./rallyCall', () => ({
 }));
 vi.mock('../../ErrorHandler', () => ({
 	ErrorHandler: {
-		getInstance: vi.fn(() => ({ handleError: vi.fn(), logError: vi.fn() }))
+		getInstance: vi.fn(() => ({
+			handleError: vi.fn(),
+			logError: vi.fn(),
+			logInfo: vi.fn(),
+			logDebug: vi.fn(),
+			logWarning: vi.fn()
+		}))
 	},
 	handleErrors: vi.fn(() => (_target: any, _key: string, descriptor: PropertyDescriptor) => descriptor),
 	handleErrorsSync: vi.fn(() => (_target: any, _key: string, descriptor: PropertyDescriptor) => descriptor)
@@ -32,7 +58,38 @@ vi.mock('./CacheService', () => ({
 	clearAllCaches: vi.fn()
 }));
 
-import { extractIterationId, checkCacheForFilteredResults } from './rallyServices';
+import { extractIterationId, checkCacheForFilteredResults, getUserStories } from './rallyServices';
+import { callRally } from './rallyCall';
+
+function rawStory(overrides: Record<string, unknown>) {
+	return {
+		ObjectID: overrides.objectId ?? '1',
+		FormattedID: overrides.formattedId ?? 'US1',
+		Name: overrides.name ?? 'Story',
+		Owner: { _refObjectName: 'Owner' },
+		Description: '',
+		State: null,
+		PlanEstimate: 1,
+		ToDo: 0,
+		c_Assignee: { _refObjectName: overrides.assignee ?? 'Unassigned' },
+		Project: { _refObjectName: 'Team.CC IBM_CC' },
+		Iteration: {
+			ObjectID: overrides.iterationId ?? '83178439645',
+			_ref: `/iteration/${overrides.iterationId ?? '83178439645'}`,
+			_refObjectName: 'Sprint 92'
+		},
+		Blocked: false,
+		TaskEstimateTotal: overrides.taskEstimateTotal ?? 0,
+		TaskStatus: 'DEFINED',
+		Tasks: { Count: 0 },
+		TestCases: { Count: 0 },
+		Defects: { Count: 0 },
+		Discussion: { Count: 0 },
+		ScheduleState: overrides.scheduleState ?? 'In-Progress',
+		c_Appgar: null,
+		RevisionHistory: null
+	};
+}
 
 describe('extractIterationId', () => {
 	it("extreu objectId d'un ref curt", () => {
@@ -70,5 +127,84 @@ describe('checkCacheForFilteredResults (Iteration matching)', () => {
 	it('retorna null si cap story coincideix amb la iteració', () => {
 		const r = checkCacheForFilteredResults({ Iteration: '/iteration/00000' } as any, stories);
 		expect(r).toBeNull();
+	});
+});
+
+describe('getUserStories (Iteration filter completeness)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		rallyData.userStories.length = 0;
+	});
+
+	it('does not return an incomplete progressive cache for Iteration filters; fetches from API instead', async () => {
+		// Progressive cache only has one story for Sprint 92 (e.g. from "All User Stories" first page),
+		// missing Rubén's US with 210h that also belongs to the same sprint.
+		rallyData.userStories.push({
+			objectId: '91229071621',
+			formattedId: 'US1705726',
+			name: 'Gestión de comentarios apps en TrustPilot',
+			assignee: 'Rubén Moreno Leiva',
+			taskEstimateTotal: 0,
+			iteration: { objectId: '83178439645', _ref: '/iteration/83178439645', _refObjectName: 'Sprint 92' }
+		});
+
+		vi.mocked(callRally).mockResolvedValueOnce({
+			Results: [
+				rawStory({
+					objectId: '91229071621',
+					formattedId: 'US1705726',
+					name: 'Gestión de comentarios apps en TrustPilot',
+					assignee: 'Rubén Moreno Leiva',
+					taskEstimateTotal: 0,
+					iterationId: '83178439645'
+				}),
+				rawStory({
+					objectId: '81597964629',
+					formattedId: 'US1313591',
+					name: 'Gestión de comentarios apps en iOS (App Store)',
+					assignee: 'Rubén Moreno Leiva',
+					taskEstimateTotal: 210,
+					iterationId: '83178439645'
+				})
+			]
+		});
+
+		const result = await getUserStories({ Iteration: '/iteration/83178439645' });
+
+		expect(callRally).toHaveBeenCalled();
+		expect(result.source).toBe('api');
+		expect(result.userStories.map((s: any) => s.formattedId).sort()).toEqual(['US1313591', 'US1705726']);
+		const rubenHours = result.userStories.filter((s: any) => s.assignee === 'Rubén Moreno Leiva').reduce((sum: number, s: any) => sum + (s.taskEstimateTotal || 0), 0);
+		expect(rubenHours).toBe(210);
+	});
+
+	it('fetches all pages when an Iteration filter returns more than one page', async () => {
+		const page1 = Array.from({ length: 100 }, (_, i) =>
+			rawStory({
+				objectId: String(1000 + i),
+				formattedId: `US${2000000 - i}`,
+				taskEstimateTotal: 1,
+				iterationId: '83178439645',
+				assignee: 'Someone'
+			})
+		);
+		const page2 = [
+			rawStory({
+				objectId: '81597964629',
+				formattedId: 'US1313591',
+				assignee: 'Rubén Moreno Leiva',
+				taskEstimateTotal: 210,
+				iterationId: '83178439645'
+			})
+		];
+
+		vi.mocked(callRally).mockResolvedValueOnce({ Results: page1 }).mockResolvedValueOnce({ Results: page2 });
+
+		const result = await getUserStories({ Iteration: '/iteration/83178439645' });
+
+		expect(callRally).toHaveBeenCalledTimes(2);
+		expect(result.userStories).toHaveLength(101);
+		expect(result.hasMore).toBe(false);
+		expect(result.userStories.some((s: any) => s.formattedId === 'US1313591' && s.taskEstimateTotal === 210)).toBe(true);
 	});
 });

--- a/src/libs/rally/rallyServices.ts
+++ b/src/libs/rally/rallyServices.ts
@@ -883,28 +883,59 @@ export async function getIterations(query: RallyQueryParams = {}, limit: number 
 	};
 }
 
+/**
+ * Builds Rally query options for user stories, always scoped to the configured project
+ * unless the caller already provided a Project filter.
+ */
+async function buildScopedUserStoryQueryOptions(query: RallyQueryParams, offset: number = 0): Promise<RallyQueryOptions> {
+	const queryOptions = buildUserStoryQueryOptions(query, offset);
+
+	if (!query?.Project) {
+		const projectId = await getProjectId();
+		const projectQuery = queryUtils.where('Project', '=', `/project/${projectId}`);
+
+		if (queryOptions.query) {
+			// @ts-expect-error - Rally query builder has and method
+			queryOptions.query = queryOptions.query.and(projectQuery);
+		} else {
+			queryOptions.query = projectQuery;
+		}
+	}
+
+	return queryOptions;
+}
+
+/**
+ * Fetches a single page of user stories from Rally and merges them into the progressive cache.
+ */
+async function fetchUserStoriesPage(query: RallyQueryParams, offset: number, loadingMessage: string): Promise<{ userStories: RallyUserStory[]; rawCount: number }> {
+	const rallyApi = getRallyApi();
+	const queryOptions = await buildScopedUserStoryQueryOptions(query, offset);
+	const result = await callRally(rallyApi, queryOptions, loadingMessage);
+	const resultData = result as RallyApiResult;
+	const results = resultData.Results || resultData.QueryResult?.Results || [];
+
+	if (!results.length) {
+		return { userStories: [], rawCount: 0 };
+	}
+
+	const userStories = await formatUserStoriesAsync({ ...resultData, Results: results });
+	if (!rallyData.userStories) {
+		rallyData.userStories = [];
+	}
+	addToCache(userStories, rallyData.userStories, 'objectId');
+	return { userStories, rawCount: results.length };
+}
+
 export async function getUserStories(query: RallyQueryParams = {}, offset: number = 0) {
 	errorHandler.logDebug(`getUserStories called with query: ${JSON.stringify(query)}, offset: ${offset}`, 'rallyServices.getUserStories');
 
-	// For filtered queries (e.g., by iteration), use cache if available
 	const hasFilters = Object.keys(query).length > 0;
-	if (hasFilters) {
-		// Fall back to in-memory cache for filtered results
-		const cacheResult = checkCacheForFilteredResults(query as RallyQuery, rallyData.userStories);
-		if (cacheResult) {
-			const sorted = sortByFormattedIdDescending(cacheResult.results);
-			const paginated = sorted.slice(offset, offset + PAGE_SIZE);
-			const hasMore = offset + PAGE_SIZE < sorted.length;
-			return {
-				userStories: paginated,
-				source: cacheResult.source,
-				count: paginated.length,
-				totalCount: sorted.length,
-				hasMore: hasMore,
-				offset: offset
-			};
-		}
-	}
+
+	// Do NOT serve filtered queries (e.g. by Iteration) from the progressive in-memory cache.
+	// That cache is filled by paginated "all user stories" loads and is often incomplete/stale,
+	// which under-reports assignee hours in sprint detail and team progress views.
+	// Always fetch filtered queries from the Rally API for completeness and freshness.
 
 	// For non-filtered queries (all user stories), only use cache if it's complete
 	// Check if cache has enough data for this offset
@@ -929,29 +960,35 @@ export async function getUserStories(query: RallyQueryParams = {}, offset: numbe
 		}
 	}
 
-	// For non-filtered queries (all user stories), always fetch from Rally for proper pagination
-	// This ensures each "Load more" fetches the next page from Rally
-	const rallyApi = getRallyApi();
-	const queryOptions = buildUserStoryQueryOptions(query, offset);
+	// Filtered queries need the full matching set (hours charts, team progress).
+	// Paginate through Rally until exhaustion when starting from offset 0.
+	if (hasFilters && offset === 0) {
+		const allStories: RallyUserStory[] = [];
+		let pageOffset = 0;
+		let pageRawCount = 0;
 
-	// Always filter by project (unless Project is already specified in the query)
-	if (!query?.Project) {
-		const projectId = await getProjectId();
-		const projectQuery = queryUtils.where('Project', '=', `/project/${projectId}`);
+		do {
+			const page = await fetchUserStoriesPage(query, pageOffset, pageOffset === 0 ? 'Loading user stories...' : 'Loading more user stories...');
+			allStories.push(...page.userStories);
+			pageRawCount = page.rawCount;
+			pageOffset += PAGE_SIZE;
+		} while (pageRawCount === PAGE_SIZE);
 
-		if (queryOptions.query) {
-			// @ts-expect-error - Rally query builder has and method
-			queryOptions.query = queryOptions.query.and(projectQuery);
-		} else {
-			queryOptions.query = projectQuery;
-		}
+		errorHandler.logInfo(`Loaded ${allStories.length} filtered user stories from API (complete set)`, 'rallyServices.getUserStories');
+
+		return {
+			userStories: allStories,
+			source: 'api',
+			count: allStories.length,
+			totalCount: allStories.length,
+			hasMore: false,
+			offset: 0
+		};
 	}
 
-	const result = await callRally(rallyApi, queryOptions, 'Loading user stories...');
-	const resultData = result as RallyApiResult;
-
-	const results = resultData.Results || resultData.QueryResult?.Results || [];
-	if (!results.length) {
+	// Single-page fetch for unfiltered pagination (or filtered with explicit offset)
+	const page = await fetchUserStoriesPage(query, offset, 'Loading user stories...');
+	if (!page.userStories.length) {
 		return {
 			userStories: [],
 			source: 'api',
@@ -962,21 +999,12 @@ export async function getUserStories(query: RallyQueryParams = {}, offset: numbe
 		};
 	}
 
-	// Format the response
-	const userStories = await formatUserStoriesAsync({ ...resultData, Results: results });
-
-	// Add new user stories to rallyData progressively without duplicates
-	addToCache(userStories, rallyData.userStories, 'objectId');
-
-	// Results are already ordered by Rally (FormattedID desc), no need to sort locally
-	// Determine if there are more results
-	// Rally API typically returns pageSize items, and if we got exactly PAGE_SIZE items, there might be more
-	const hasMore = results.length === PAGE_SIZE;
+	const hasMore = page.rawCount === PAGE_SIZE;
 
 	return {
-		userStories: userStories,
+		userStories: page.userStories,
 		source: 'api',
-		count: userStories.length,
+		count: page.userStories.length,
 		totalCount: 0, // We don't know the total until we've fetched all pages
 		hasMore: hasMore,
 		offset: offset


### PR DESCRIPTION
## Summary
- Sprint detail was showing wrong assignee hours (e.g. Rubén Moreno at 0h) because Iteration-filtered `getUserStories` returned an incomplete progressive cache from paginated "All User Stories" loads instead of fetching the full sprint set from Rally.
- Filtered queries now always hit the API and paginate until the complete matching set is loaded, so charts and tables include all stories and their `TaskEstimateTotal` values.
- Added regression tests covering incomplete-cache bypass and multi-page Iteration fetches.

## Test plan
- [ ] Open Portfolio → Sprints → Sprint 92 and confirm Rubén Moreno shows US1313591 with 210h (not only US1705726 at 0h)
- [ ] Confirm Assignee hours chart totals match Rally Iteration Status Task Estimate
- [ ] `npx vitest run src/libs/rally/rallyServices.test.ts`
- [ ] Spot-check Team member progress for the same sprint still loads hours