### PR TITLE
feat: enhance caching and data freshness management in rally services

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { SettingsManager } from './SettingsManager';
 import type { RallyData, Iteration } from './types/rally';
 import { OutputChannelManager } from './utils/OutputChannelManager';
 import { clearAllRallyCaches } from './libs/rally/rallyServices';
+import type { CacheEntity } from './libs/cache/ttlConfig';
 import { detectDebugMode, getTestTabEnabledReason, initDevMode, isTestTabEnabled } from './utils/devMode';
 import { WebviewMessageDispatcher } from './webview/messageHandlers/WebviewMessageDispatcher';
 
@@ -18,6 +19,25 @@ export const rallyData: RallyData = {
 	defects: [],
 	currentUser: undefined
 };
+
+/**
+ * Timestamps paral·lels de l'última escriptura a rallyData, per entitat.
+ * Permet aplicar un TTL d'edat a la branca de fallback in-memory sense modificar
+ * el tipus RallyData ni la forma dels objectes cachejats.
+ */
+export const rallyDataMeta: Partial<Record<CacheEntity, number>> = {};
+
+/** Estampa el moment de l'últim upsert exitós d'una entitat a rallyData. */
+export function stampRallyData(entity: CacheEntity, when: number = Date.now()): void {
+	rallyDataMeta[entity] = when;
+}
+
+/** Buida tots els timestamps de rallyData (usat al reload). */
+export function clearRallyDataMeta(): void {
+	for (const key of Object.keys(rallyDataMeta) as CacheEntity[]) {
+		delete rallyDataMeta[key];
+	}
+}
 
 // Store global references for reload functionality
 let globalWebviewProvider: RobertWebviewProvider | null = null;
@@ -52,6 +72,7 @@ async function reloadExtension(outputManager: OutputChannelManager, _errorHandle
 		rallyData.tasks = [];
 		rallyData.defects = [];
 		rallyData.currentUser = undefined;
+		clearRallyDataMeta();
 
 		WebviewMessageDispatcher.clearSessionNavigationState();
 

--- a/src/libs/cache/CacheManager.test.ts
+++ b/src/libs/cache/CacheManager.test.ts
@@ -128,6 +128,48 @@ describe('CacheManager', () => {
 		});
 	});
 
+	describe('getWithMeta', () => {
+		it('should return data with metadata when the entry exists', () => {
+			cache.set('key1', 'value1', 1000);
+			const result = cache.getWithMeta('key1');
+			expect(result).not.toBeNull();
+			expect(result?.data).toBe('value1');
+			expect(result?.ttl).toBe(1000);
+			expect(typeof result?.timestamp).toBe('number');
+		});
+
+		it('should return null for non-existent keys', () => {
+			expect(cache.getWithMeta('non-existent')).toBeNull();
+		});
+
+		it('should return the entry even when get() would treat it as expired', async () => {
+			cache.set('key1', 'value1', 500);
+			await new Promise(resolve => setTimeout(resolve, 600));
+
+			// get() applies TTL and evicts; getWithMeta bypasses TTL entirely
+			expect(cache.get('key1')).toBeNull();
+
+			// Re-set because get() evicted the entry above
+			cache.set('key2', 'value2', 500);
+			await new Promise(resolve => setTimeout(resolve, 600));
+			const result = cache.getWithMeta('key2');
+			expect(result).not.toBeNull();
+			expect(result?.data).toBe('value2');
+		});
+
+		it('should count present entries as hits and absent ones as misses', () => {
+			cache.set('key1', 'value1');
+
+			cache.getWithMeta('key1'); // hit
+			cache.getWithMeta('key1'); // hit
+			cache.getWithMeta('non-existent'); // miss
+
+			const stats = cache.getStats();
+			expect(stats.hits).toBe(2);
+			expect(stats.misses).toBe(1);
+		});
+	});
+
 	describe('Cache size and entries', () => {
 		it('should report correct cache size', () => {
 			cache.set('key1', 'value1');

--- a/src/libs/cache/CacheManager.ts
+++ b/src/libs/cache/CacheManager.ts
@@ -65,8 +65,12 @@ export class CacheManager<T> {
 	getWithMeta(key: string): { data: T; timestamp: number; ttl: number } | null {
 		const entry = this.cache.get(key);
 		if (!entry) {
+			this.stats.misses++;
 			return null;
 		}
+		// Compta com a hit quan l'entrada existeix. La decisió de staleness la pren el
+		// cridant (via maxAge), per això no s'aplica TTL ni evicció aquí.
+		this.stats.hits++;
 		return { data: entry.data, timestamp: entry.timestamp, ttl: entry.ttl };
 	}
 

--- a/src/libs/cache/CacheManager.ts
+++ b/src/libs/cache/CacheManager.ts
@@ -57,6 +57,20 @@ export class CacheManager<T> {
 	}
 
 	/**
+	 * Get value together with its cache metadata (timestamp + ttl) WITHOUT applying
+	 * the entry's own TTL. Lets the caller decide staleness with a per-call maxAge
+	 * (e.g. velocity forcing a shorter freshness window over iterations).
+	 * Returns null only when the key is absent.
+	 */
+	getWithMeta(key: string): { data: T; timestamp: number; ttl: number } | null {
+		const entry = this.cache.get(key);
+		if (!entry) {
+			return null;
+		}
+		return { data: entry.data, timestamp: entry.timestamp, ttl: entry.ttl };
+	}
+
+	/**
 	 * Set value in cache with optional custom TTL
 	 */
 	set(key: string, value: T, ttlMs?: number): void {

--- a/src/libs/cache/ttlConfig.ts
+++ b/src/libs/cache/ttlConfig.ts
@@ -51,15 +51,15 @@ export function ttlFor(entity: CacheEntity): number {
 
 /**
  * Retorna true si la dada és stale (cal re-fetchar).
- * - TTL no finit (Infinity) ⇒ mai stale.
- * - `fetchedAt` absent/0 ⇒ stale (mai carregat).
+ * - `fetchedAt` absent/0 ⇒ stale (mai carregat), fins i tot amb TTL Infinity.
+ * - TTL no finit (Infinity) ⇒ mai stale un cop carregat.
  */
 export function isStale(fetchedAt: number, ttl: number, now: number = Date.now()): boolean {
-	if (!Number.isFinite(ttl)) {
-		return false; // Infinity → mai caduca
-	}
 	if (!fetchedAt) {
-		return true; // mai carregat
+		return true; // mai carregat → sempre stale
+	}
+	if (!Number.isFinite(ttl)) {
+		return false; // Infinity → mai caduca un cop carregat
 	}
 	return now - fetchedAt > ttl;
 }

--- a/src/libs/cache/ttlConfig.ts
+++ b/src/libs/cache/ttlConfig.ts
@@ -1,0 +1,74 @@
+/**
+ * ttlConfig - Autoritat única de TTL (Time To Live) per entitat de Rally.
+ *
+ * Cada entitat té un temps de validesa propi. La revalidació és LAZY: les dades
+ * només es tornen a demanar quan s'hi interactua i s'han tornat més velles que el
+ * seu TTL (no hi ha cap refresc automàtic per timer).
+ *
+ * `Infinity` = mai caduca després del primer fetch (viu tota la sessió).
+ */
+
+export type CacheEntity =
+	| 'projects'
+	| 'holidays'
+	| 'users'
+	| 'iterations'
+	| 'velocity'
+	| 'userStories'
+	| 'tasks'
+	| 'defects'
+	| 'teamMembers'
+	| 'currentUser'
+	| 'revisions';
+
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+
+/**
+ * TTL per entitat en mil·lisegons. Valors decidits per producte.
+ * `projects` i `currentUser` no canvien durant una sessió → Infinity.
+ * La resta d'entitats operatives comparteixen 30 min ("tot lo demés").
+ */
+export const TTL_MS: Record<CacheEntity, number> = {
+	projects: Infinity,
+	currentUser: Infinity,
+	holidays: 24 * HOUR,
+	users: 4 * HOUR,
+	iterations: 48 * HOUR,
+	velocity: 24 * HOUR,
+	// "tot lo demés" = 30 min
+	userStories: 30 * MIN,
+	tasks: 30 * MIN,
+	defects: 30 * MIN,
+	teamMembers: 30 * MIN,
+	revisions: 30 * MIN
+};
+
+/** TTL per defecte d'una entitat. */
+export function ttlFor(entity: CacheEntity): number {
+	return TTL_MS[entity];
+}
+
+/**
+ * Retorna true si la dada és stale (cal re-fetchar).
+ * - TTL no finit (Infinity) ⇒ mai stale.
+ * - `fetchedAt` absent/0 ⇒ stale (mai carregat).
+ */
+export function isStale(fetchedAt: number, ttl: number, now: number = Date.now()): boolean {
+	if (!Number.isFinite(ttl)) {
+		return false; // Infinity → mai caduca
+	}
+	if (!fetchedAt) {
+		return true; // mai carregat
+	}
+	return now - fetchedAt > ttl;
+}
+
+/**
+ * Serialitza un TTL per enviar-lo al webview via postMessage.
+ * `Infinity` no sobreviu a JSON/structuredClone de forma consistent → s'envia `null`,
+ * que el frontend tracta com "mai stale".
+ */
+export function serializeTtl(ttl: number): number | null {
+	return Number.isFinite(ttl) ? ttl : null;
+}

--- a/src/libs/rally/rallyServices.test.ts
+++ b/src/libs/rally/rallyServices.test.ts
@@ -20,7 +20,7 @@ const { rallyData, queryBuilder } = vi.hoisted(() => {
 
 // Mock vscode i extension per evitar efectes secundaris en importar rallyServices
 vi.mock('vscode', () => ({ default: {}, workspace: {}, window: {}, commands: {}, Uri: {} }));
-vi.mock('../../extension.js', () => ({ rallyData }));
+vi.mock('../../extension.js', () => ({ rallyData, rallyDataMeta: {}, stampRallyData: vi.fn() }));
 vi.mock('./utils', () => ({
 	getRallyApi: vi.fn(() => ({})),
 	queryUtils: {
@@ -50,11 +50,11 @@ vi.mock('../../ErrorHandler', () => ({
 }));
 vi.mock('../../SettingsManager', () => ({ SettingsManager: { getInstance: vi.fn(() => ({ getSettings: vi.fn(() => ({})) })) } }));
 vi.mock('./CacheService', () => ({
-	getUserStoriesCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn() })),
-	getProjectsCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn() })),
-	getIterationsCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn() })),
-	getTeamMembersCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn() })),
-	getUsersCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn() })),
+	getUserStoriesCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn(), getWithMeta: vi.fn(() => null) })),
+	getProjectsCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn(), getWithMeta: vi.fn(() => null) })),
+	getIterationsCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn(), getWithMeta: vi.fn(() => null) })),
+	getTeamMembersCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn(), getWithMeta: vi.fn(() => null) })),
+	getUsersCacheManager: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), has: vi.fn(), getWithMeta: vi.fn(() => null) })),
 	clearAllCaches: vi.fn()
 }));
 

--- a/src/libs/rally/rallyServices.ts
+++ b/src/libs/rally/rallyServices.ts
@@ -1,4 +1,5 @@
-import { rallyData } from '../../extension.js';
+import { rallyData, rallyDataMeta, stampRallyData } from '../../extension.js';
+import { ttlFor, isStale, type CacheEntity } from '../cache/ttlConfig';
 import type { RallyApiObject, RallyApiResult, RallyProject, RallyQuery, RallyQueryBuilder, RallyQueryOptions, RallyQueryParams, RallyUser, RallyUserStory, RallyIteration, RallyDefect, User, GlobalSearchResultItem } from '../../types/rally';
 import { getRallyApi, queryUtils, validateRallyConfiguration, getProjectId, clearUtilsCaches } from './utils';
 import { callRally, callRallyFetch, setRallyBroadcaster } from './rallyCall';
@@ -47,6 +48,41 @@ function yieldToEventLoop(): Promise<void> {
 // Constants for pagination
 const PAGE_SIZE = 100;
 
+/** Formata una durada en ms de forma llegible per als logs de cache (∞ per Infinity). */
+function formatCacheMs(ms: number): string {
+	if (!Number.isFinite(ms)) {
+		return '∞';
+	}
+	if (ms < 60_000) {
+		return `${Math.round(ms / 1000)}s`;
+	}
+	if (ms < 3_600_000) {
+		return `${Math.round(ms / 60_000)}m`;
+	}
+	return `${Math.round((ms / 3_600_000) * 10) / 10}h`;
+}
+
+/**
+ * Retorna true si la branca de fallback in-memory (rallyData) d'una entitat és prou
+ * fresca per servir-se sense tornar a l'API. Quan és stale, el cridant ha de fer fetch.
+ * `maxAge` (ms) permet forçar una finestra de frescor més curta que el TTL per defecte
+ * (p.ex. velocity forçant 24h sobre iterations de 48h).
+ *
+ * Deixa traça de la decisió al canal "Robert" amb nivell debug (entitat, edat, TTL, veredicte).
+ */
+function rallyDataFresh(entity: CacheEntity, maxAge?: number): boolean {
+	const fetchedAt = rallyDataMeta[entity] ?? 0;
+	const ttl = maxAge ?? ttlFor(entity);
+	const fresh = !isStale(fetchedAt, ttl);
+	const ageLabel = fetchedAt ? formatCacheMs(Date.now() - fetchedAt) : 'never';
+	const overrideLabel = maxAge != null ? ' [maxAge override]' : '';
+	errorHandler.logDebug(
+		`[cache] ${entity}: ${fresh ? 'FRESH → serve from rallyData' : 'STALE → refetch from API'} (age=${ageLabel}, ttl=${formatCacheMs(ttl)}${overrideLabel})`,
+		'rallyServices.cache'
+	);
+	return fresh;
+}
+
 export { setRallyBroadcaster };
 
 /**
@@ -94,6 +130,7 @@ export async function getProjects(query: Record<string, unknown> = {}, limit: nu
 	const projectsCacheMgr = getProjectsCacheManager();
 	const cachedProjects = projectsCacheMgr.get(cacheKey);
 	if (cachedProjects) {
+		errorHandler.logDebug(`[cache] projects(ttl-layer): FRESH → serve from ttl-cache (ttl=${formatCacheMs(ttlFor('projects'))})`, 'rallyServices.cache');
 		return {
 			projects: cachedProjects,
 			source: 'ttl-cache',
@@ -101,8 +138,8 @@ export async function getProjects(query: Record<string, unknown> = {}, limit: nu
 		};
 	}
 
-	// Fall back to in-memory cache for filtered results
-	if (Object.keys(query).length && rallyData.projects.length) {
+	// Fall back to in-memory cache for filtered results (only if not stale)
+	if (Object.keys(query).length && rallyData.projects.length && rallyDataFresh('projects')) {
 		const filteredProjects = rallyData.projects.filter((project: RallyProject) =>
 			Object.keys(query).every(key => {
 				if (project[key as keyof RallyProject] === undefined) {
@@ -156,7 +193,7 @@ export async function getProjects(query: Record<string, unknown> = {}, limit: nu
 	const results = resultData.Results || resultData.QueryResult?.Results || [];
 	if (!results.length) {
 		// Cache empty results too
-		projectsCacheMgr.set(cacheKey, []);
+		projectsCacheMgr.set(cacheKey, [], ttlFor('projects'));
 		return {
 			projects: [],
 			source: 'api',
@@ -179,9 +216,10 @@ export async function getProjects(query: Record<string, unknown> = {}, limit: nu
 			rallyData.projects[existingProjectIndex] = newProject;
 		}
 	}
+	stampRallyData('projects');
 
 	// Store in TTL cache
-	projectsCacheMgr.set(cacheKey, projects);
+	projectsCacheMgr.set(cacheKey, projects, ttlFor('projects'));
 
 	return {
 		projects: projects,
@@ -191,8 +229,8 @@ export async function getProjects(query: Record<string, unknown> = {}, limit: nu
 }
 
 export async function getCurrentUser() {
-	// If we already have the current user from prefetch, return it
-	if (rallyData.currentUser) {
+	// If we already have the current user from prefetch, return it (only if not stale)
+	if (rallyData.currentUser && rallyDataFresh('currentUser')) {
 		return {
 			user: rallyData.currentUser,
 			source: 'cache'
@@ -275,6 +313,7 @@ export async function getCurrentUser() {
 
 			// Cache the user data
 			rallyData.currentUser = userData;
+			stampRallyData('currentUser');
 
 			return {
 				user: userData,
@@ -305,6 +344,7 @@ export async function getUsers(query: RallyQueryParams = {}, limit: number | nul
 	const usersCacheMgr = getUsersCacheManager();
 	const cachedUsers = usersCacheMgr.get(cacheKey);
 	if (cachedUsers) {
+		errorHandler.logDebug(`[cache] users(ttl-layer): FRESH → serve from ttl-cache (ttl=${formatCacheMs(ttlFor('users'))})`, 'rallyServices.cache');
 		return {
 			users: cachedUsers,
 			source: 'ttl-cache',
@@ -312,8 +352,8 @@ export async function getUsers(query: RallyQueryParams = {}, limit: number | nul
 		};
 	}
 
-	//Si hi ha filtres específics, comprovem si podem satisfer-los amb la cache
-	if (Object.keys(query).length && rallyData.users && rallyData.users.length) {
+	//Si hi ha filtres específics, comprovem si podem satisfer-los amb la cache (només si no és stale)
+	if (Object.keys(query).length && rallyData.users && rallyData.users.length && rallyDataFresh('users')) {
 		const filteredUsers = rallyData.users.filter((user: RallyUser) =>
 			Object.keys(query).every(key => {
 				if (user[key as keyof RallyUser] === undefined) {
@@ -367,7 +407,7 @@ export async function getUsers(query: RallyQueryParams = {}, limit: number | nul
 
 	const results = resultData.Results || resultData.QueryResult?.Results || [];
 	if (!results.length) {
-		usersCacheMgr.set(cacheKey, []);
+		usersCacheMgr.set(cacheKey, [], ttlFor('users'));
 		return {
 			users: [],
 			source: 'api',
@@ -393,9 +433,10 @@ export async function getUsers(query: RallyQueryParams = {}, limit: number | nul
 			rallyData.users[existingUserIndex] = newUser;
 		}
 	}
+	stampRallyData('users');
 
 	// Store in TTL cache
-	usersCacheMgr.set(cacheKey, users);
+	usersCacheMgr.set(cacheKey, users, ttlFor('users'));
 
 	return {
 		users: users,
@@ -747,26 +788,37 @@ function buildUserStoryQueryOptions(query: RallyQueryParams, offset: number = 0)
 	return queryOptions;
 }
 
-export async function getIterations(query: RallyQueryParams = {}, limit: number | null = null) {
+export async function getIterations(query: RallyQueryParams = {}, limit: number | null = null, opts?: { maxAge?: number }) {
 	errorHandler.logDebug(`getIterations called with query: ${JSON.stringify(query)}, limit: ${limit}`, 'rallyServices.getIterations');
 
 	// Generate cache key from query
 	const cacheKey = `iterations:${JSON.stringify(query)}`;
 
-	// Check TTL cache first
+	// Effective freshness window: a per-call maxAge (e.g. velocity forcing 24h) overrides the
+	// entity default (48h). Applied to BOTH cache layers so a caller can demand fresher data.
+	const iterationsTtl = opts?.maxAge ?? ttlFor('iterations');
+
+	// Check TTL cache first (honouring the effective freshness window, not the stored ttl)
 	const iterationsCacheMgr = getIterationsCacheManager();
-	const cachedIterations = iterationsCacheMgr.get(cacheKey);
-	if (cachedIterations) {
-		errorHandler.logDebug('Iterations retrieved from TTL cache', 'rallyServices.getIterations');
-		return {
-			iterations: cachedIterations,
-			source: 'ttl-cache',
-			count: cachedIterations.length
-		};
+	const cachedHit = iterationsCacheMgr.getWithMeta(cacheKey);
+	if (cachedHit) {
+		const fresh = !isStale(cachedHit.timestamp, iterationsTtl);
+		const overrideLabel = opts?.maxAge != null ? ' [maxAge override]' : '';
+		errorHandler.logDebug(
+			`[cache] iterations(ttl-layer): ${fresh ? 'FRESH → serve from ttl-cache' : 'STALE → refetch from API'} (age=${formatCacheMs(Date.now() - cachedHit.timestamp)}, ttl=${formatCacheMs(iterationsTtl)}${overrideLabel})`,
+			'rallyServices.cache'
+		);
+		if (fresh) {
+			return {
+				iterations: cachedHit.data,
+				source: 'ttl-cache',
+				count: cachedHit.data.length
+			};
+		}
 	}
 
-	// Fall back to in-memory cache for filtered results
-	if (Object.keys(query).length && rallyData.iterations && rallyData.iterations.length) {
+	// Fall back to in-memory cache for filtered results (only if not stale)
+	if (Object.keys(query).length && rallyData.iterations && rallyData.iterations.length && rallyDataFresh('iterations', opts?.maxAge)) {
 		const filteredIterations = rallyData.iterations.filter((iteration: any) =>
 			Object.keys(query).every(key => {
 				if (iteration[key as keyof any] === undefined) {
@@ -826,7 +878,7 @@ export async function getIterations(query: RallyQueryParams = {}, limit: number 
 	if (!results.length) {
 		// Cache empty results too
 		const iterationsCacheMgr = getIterationsCacheManager();
-		iterationsCacheMgr.set(cacheKey, []);
+		iterationsCacheMgr.set(cacheKey, [], ttlFor('iterations'));
 		return {
 			iterations: [],
 			source: 'api',
@@ -864,9 +916,10 @@ export async function getIterations(query: RallyQueryParams = {}, limit: number 
 			rallyData.iterations[existingIterationIndex] = newIteration;
 		}
 	}
+	stampRallyData('iterations');
 
-	// Store in TTL cache
-	iterationsCacheMgr.set(cacheKey, iterations);
+	// Store in TTL cache (always with the entity default ttl; per-call maxAge only affects reads)
+	iterationsCacheMgr.set(cacheKey, iterations, ttlFor('iterations'));
 
 	return {
 		iterations: iterations,
@@ -916,6 +969,7 @@ async function fetchUserStoriesPage(query: RallyQueryParams, offset: number, loa
 		rallyData.userStories = [];
 	}
 	addToCache(userStories, rallyData.userStories, 'objectId');
+	stampRallyData('userStories');
 	return { userStories, rawCount: results.length };
 }
 
@@ -931,7 +985,7 @@ export async function getUserStories(query: RallyQueryParams = {}, offset: numbe
 
 	// For non-filtered queries (all user stories), only use cache if it's complete
 	// Check if cache has enough data for this offset
-	if (!hasFilters && offset > 0 && rallyData.userStories && rallyData.userStories.length > 0) {
+	if (!hasFilters && offset > 0 && rallyData.userStories && rallyData.userStories.length > 0 && rallyDataFresh('userStories')) {
 		const sorted = sortByFormattedIdDescending(rallyData.userStories);
 		// Only use cache if it has data at the requested offset
 		if (sorted.length > offset) {
@@ -1014,8 +1068,8 @@ export async function getTasks(userStoryId: string, query: RallyQueryParams = {}
 		throw new Error(`Rally configuration error: ${validation.errors.join(', ')}`);
 	}
 
-	//Si hi ha filtres específics, comprovem si podem satisfer-los amb la cache
-	if (Object.keys(query).length && rallyData.tasks && rallyData.tasks.length) {
+	//Si hi ha filtres específics, comprovem si podem satisfer-los amb la cache (només si no és stale)
+	if (Object.keys(query).length && rallyData.tasks && rallyData.tasks.length && rallyDataFresh('tasks')) {
 		const filteredTasks = rallyData.tasks.filter((task: any) =>
 			Object.keys(query).every(key => {
 				if (task[key as keyof any] === undefined) {
@@ -1094,6 +1148,7 @@ export async function getTasks(userStoryId: string, query: RallyQueryParams = {}
 			rallyData.tasks[existingTaskIndex] = newTask;
 		}
 	}
+	stampRallyData('tasks');
 
 	return {
 		tasks: tasks,
@@ -1111,8 +1166,8 @@ export async function getDefects(query: RallyQueryParams = {}, offset: number = 
 	// If filtered, skip pagination
 	const isFiltered = Object.keys(query).length > 0;
 
-	//Si hi ha filtres específics, comprovem si podem satisfer-los amb la cache
-	if (isFiltered && rallyData.defects && rallyData.defects.length) {
+	//Si hi ha filtres específics, comprovem si podem satisfer-los amb la cache (només si no és stale)
+	if (isFiltered && rallyData.defects && rallyData.defects.length && rallyDataFresh('defects')) {
 		const filteredDefects = rallyData.defects.filter((defect: RallyDefect) =>
 			Object.keys(query).every(key => {
 				if (defect[key as keyof RallyDefect] === undefined) {
@@ -1134,7 +1189,7 @@ export async function getDefects(query: RallyQueryParams = {}, offset: number = 
 
 	// If offset > 0 and we have no filters, check if cache has enough data
 	// Only use cache if it contains data at the requested offset
-	if (offset > 0 && !isFiltered && rallyData.defects && rallyData.defects.length > 0) {
+	if (offset > 0 && !isFiltered && rallyData.defects && rallyData.defects.length > 0 && rallyDataFresh('defects')) {
 		const sorted = sortByFormattedIdDescending(rallyData.defects);
 		// Only use cache if it has data at the requested offset
 		if (sorted.length > offset) {
@@ -1225,6 +1280,7 @@ export async function getDefects(query: RallyQueryParams = {}, offset: number = 
 			rallyData.defects[existingDefectIndex] = newDefect;
 		}
 	}
+	stampRallyData('defects');
 
 	// If filtered query (e.g., defects of a user story), return all without pagination
 	if (isFiltered) {
@@ -1877,7 +1933,7 @@ export async function getRecentTeamMembers(numberOfIterations: number = 3) {
 		errorHandler.logInfo(`Found ${teamMembers.length} unique team members: ${teamMembers.join(', ') || 'none'}`, 'rallyServices.getRecentTeamMembers');
 
 		// Cache the results
-		teamMembersCache.set(cacheKey, teamMembers);
+		teamMembersCache.set(cacheKey, teamMembers, ttlFor('teamMembers'));
 
 		return {
 			teamMembers: teamMembers,
@@ -2130,6 +2186,7 @@ async function getBatchTasks(userStoryIds: string[]): Promise<
 				rallyData.tasks[existingTaskIndex] = task;
 			}
 		}
+		stampRallyData('tasks');
 
 		return tasksByStory;
 	} catch (error) {

--- a/src/webview/messageHandlers/RallyMessageHandler.ts
+++ b/src/webview/messageHandlers/RallyMessageHandler.ts
@@ -4,6 +4,7 @@ import { getProjects, getIterations, getUserStories, getTasks, getDefects, getCu
 import { HolidayService } from '../../libs/holidayService';
 import { SettingsManager } from '../../SettingsManager';
 import { isTestTabEnabled } from '../../utils/devMode';
+import { ttlFor } from '../../libs/cache/ttlConfig';
 
 /**
  * Handles all Rally API-related webview messages
@@ -238,7 +239,9 @@ export class RallyMessageHandler {
 	private async handleLoadVelocityData(webview: vscode.Webview): Promise<void> {
 		try {
 			this.errorHandler.logInfo('Loading velocity data (hours per sprint) from Rally API', 'RallyMessageHandler');
-			const iterationsResult = await getIterations();
+			// Velocity vol frescor de 24h; força un refetch d'iterations si les cachejades superen aquest límit,
+			// encara que la vista normal d'iterations (48h) encara les serviria de cache.
+			const iterationsResult = await getIterations({}, null, { maxAge: ttlFor('velocity') });
 			const iterations = iterationsResult?.iterations ?? [];
 			const today = new Date();
 			today.setHours(23, 59, 59, 999);


### PR DESCRIPTION
Introduces a new metadata structure for tracking timestamps of data updates in rallyData, allowing for improved cache management. Adds functions to stamp and clear these timestamps, ensuring data freshness checks before serving cached results. Updates the CacheManager to retrieve cache entries with their metadata, and modifies rally service functions to utilize these enhancements for better performance and accuracy in data retrieval.