### PR TITLE
feat: implement browser-like navigation with back and forward commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,30 @@
 				"title": "Settings",
 				"category": "IBM Robert",
 				"icon": "$(gear)"
+			},
+			{
+				"command": "robert.goBack",
+				"title": "Go to Previous View",
+				"category": "IBM Robert",
+				"icon": "$(arrow-left)"
+			},
+			{
+				"command": "robert.goForward",
+				"title": "Go to Next View",
+				"category": "IBM Robert",
+				"icon": "$(arrow-right)"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "robert.goBack",
+				"key": "alt+left",
+				"when": "robertWebviewFocused || activeWebviewPanelId == 'robert.mainPanel'"
+			},
+			{
+				"command": "robert.goForward",
+				"key": "alt+right",
+				"when": "robertWebviewFocused || activeWebviewPanelId == 'robert.mainPanel'"
 			}
 		],
 		"viewsContainers": {

--- a/src/RobertWebviewProvider.ts
+++ b/src/RobertWebviewProvider.ts
@@ -191,6 +191,15 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 	}
 
 	/**
+	 * Trigger browser-like history navigation (back/forward) in the webview.
+	 * Invoked by the robert.goBack / robert.goForward commands so the mouse side
+	 * buttons can be mapped to them from the IDE keybindings or the mouse software.
+	 */
+	public navigateHistory(direction: 'back' | 'forward'): void {
+		this.broadcastToWebviews({ command: 'navigateHistory', direction });
+	}
+
+	/**
 	 * Set debug mode state
 	 */
 	public setDebugMode(_isDebug: boolean): void {
@@ -709,6 +718,13 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 						this._websocketClient.subscribeUserStory(message.userStoryId);
 					} else if (message.command === 'unsubscribeCollaborationUserStory' && this._websocketClient.isConnected()) {
 						this._websocketClient.unsubscribeUserStory(message.userStoryId);
+					}
+
+					// Track webview focus so the Alt+Left/Right history keybindings can be
+					// scoped to when Robert has focus (via the robertWebviewFocused context key).
+					if (message.command === 'webviewFocusChanged') {
+						void vscode.commands.executeCommand('setContext', 'robertWebviewFocused', Boolean(message.focused));
+						return;
 					}
 
 					if (!handled) {

--- a/src/RobertWebviewProvider.ts
+++ b/src/RobertWebviewProvider.ts
@@ -196,7 +196,17 @@ export class RobertWebviewProvider implements vscode.WebviewViewProvider, vscode
 	 * buttons can be mapped to them from the IDE keybindings or the mouse software.
 	 */
 	public navigateHistory(direction: 'back' | 'forward'): void {
-		this.broadcastToWebviews({ command: 'navigateHistory', direction });
+		const message = { command: 'navigateHistory', direction };
+		// Target a single surface so that having both the activity-bar view and the
+		// editor panel open doesn't navigate both (each keeps its own history) and
+		// desync them. Prefer the active panel, then the visible view, else broadcast.
+		if (this._currentPanel?.active) {
+			Promise.resolve(this._currentPanel.webview.postMessage(message)).catch(() => undefined);
+		} else if (this._currentView?.visible) {
+			Promise.resolve(this._currentView.webview.postMessage(message)).catch(() => undefined);
+		} else {
+			this.broadcastToWebviews(message);
+		}
 	}
 
 	/**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -193,6 +193,20 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 	context.subscriptions.push(openStatusPanelCommand);
 
+	// Browser-like history navigation. These commands let the user map the mouse
+	// side buttons (via IDE keybindings or the mouse driver software) to back/forward,
+	// since webviews can't reliably capture the physical mouse back/forward buttons.
+	context.subscriptions.push(
+		vscode.commands.registerCommand('robert.goBack', () => {
+			errorHandler.executeWithErrorHandlingSync(() => webviewProvider.navigateHistory('back'), 'robert.goBack command');
+		})
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand('robert.goForward', () => {
+			errorHandler.executeWithErrorHandlingSync(() => webviewProvider.navigateHistory('forward'), 'robert.goForward command');
+		})
+	);
+
 	// Command to reveal the Output channel
 	context.subscriptions.push(vscode.commands.registerCommand('robert.showOutput', () => outputManager.show()));
 

--- a/src/webview/components/MainWebview.tsx
+++ b/src/webview/components/MainWebview.tsx
@@ -1124,6 +1124,9 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 			}
 
 			// Iteració seleccionada: buscar-la a les iterations ja carregades.
+			// Si l'ID no es pot resoldre (iterations encara no carregades o iteració
+			// ja no present), netegem la selecció perquè l'estat quedi determinista i
+			// no arrossegui la iteració anterior (que desincronitzaria l'historial).
 			if (key.selectedIterationId) {
 				const iteration = iterations.find(i => i.objectId === key.selectedIterationId);
 				if (iteration) {
@@ -1131,6 +1134,8 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 					if (key.currentScreen === 'userStories' || key.currentScreen === 'userStoryDetail') {
 						loadUserStories(iteration);
 					}
+				} else {
+					setSelectedIteration(null);
 				}
 			} else {
 				setSelectedIteration(null);

--- a/src/webview/components/MainWebview.tsx
+++ b/src/webview/components/MainWebview.tsx
@@ -26,6 +26,7 @@ import SearchSection from './sections/SearchSection';
 import TeamSection from './sections/TeamSection';
 import TestSection from './sections/TestSection';
 import { useSmoothScroll } from '../hooks/useSmoothScroll';
+import { useNavigationHistory, type NavKey } from '../hooks/useNavigationHistory';
 import { logDebug } from '../utils/vscodeApi';
 import { type UserStory, type Defect, type Discussion, type TestCase, type GlobalSearchResultItem, type RecentlyViewedItem, type PinnedItem, type RallyItemRef } from '../../types/rally';
 import { PinnedContext, pinnedKey } from './common/PinnedContext';
@@ -485,6 +486,12 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 	const vscode = useMemo(() => getVsCodeApi(), []);
 	const hasVsCodeApi = Boolean(vscode);
 	const { wrapperRef, contentRef } = useSmoothScroll(hasVsCodeApi);
+
+	// Pila d'historial de navegació estil navegador (back/forward amb ratolí i teclat).
+	const { pushEntry, goBack, goForward } = useNavigationHistory();
+	// Es posa a true mentre apliquem una entrada d'historial, perquè l'effect de push
+	// no torni a apilar el canvi d'estat que provoca la pròpia navegació back/forward.
+	const isNavigatingViaHistoryRef = useRef(false);
 
 	const sendMessage = useCallback(
 		(command: string | Record<string, unknown>, data?: any) => {
@@ -1085,6 +1092,82 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		attemptedUserStoryDiscussions.current.clear();
 		attemptedUserStoryTests.current.clear();
 	}, [portfolioActiveViewType]);
+
+	// Snapshot de la navegació principal actual (per apilar a l'historial).
+	// El subtab del portfolio NO forma part de la clau: ja queda determinat pel
+	// currentScreen, i incloure'l provocaria falsos passos d'historial quan la
+	// càrrega asíncrona d'un detall normalitza el subtab.
+	const getCurrentNavKey = useCallback(
+		(): NavKey => ({
+			activeSection,
+			currentScreen,
+			selectedIterationId: selectedIteration?.objectId,
+			selectedUserStoryId: selectedUserStory?.objectId,
+			selectedDefectId: selectedDefect?.objectId
+		}),
+		[activeSection, currentScreen, selectedIteration?.objectId, selectedUserStory?.objectId, selectedDefect?.objectId]
+	);
+
+	// Aplica una entrada d'historial a l'estat, reaprofitant la mateixa mecànica
+	// que el case 'restoreState' (inclosa la càrrega asíncrona d'items de detall).
+	const applyNavKey = useCallback(
+		(key: NavKey) => {
+			setActiveSection(key.activeSection as SectionType);
+			setCurrentScreen(key.currentScreen as ScreenType);
+
+			// El subtab del portfolio es deriva del currentScreen, coincidint amb la
+			// normalització que fan els carregadors asíncrons (userStoryByObjectIdLoaded
+			// força 'allUserStories', defectByObjectIdLoaded força 'allDefects').
+			if (key.activeSection === 'portfolio') {
+				const derivedView: PortfolioViewType = key.currentScreen === 'allUserStories' || key.currentScreen === 'userStoryDetail' ? 'allUserStories' : key.currentScreen === 'defects' || key.currentScreen === 'defectDetail' ? 'allDefects' : 'bySprints';
+				setActiveSubTabBySection(prev => ({ ...prev, portfolio: derivedView }));
+			}
+
+			// Iteració seleccionada: buscar-la a les iterations ja carregades.
+			if (key.selectedIterationId) {
+				const iteration = iterations.find(i => i.objectId === key.selectedIterationId);
+				if (iteration) {
+					setSelectedIteration(iteration);
+					if (key.currentScreen === 'userStories' || key.currentScreen === 'userStoryDetail') {
+						loadUserStories(iteration);
+					}
+				}
+			} else {
+				setSelectedIteration(null);
+			}
+
+			// User story de detall: es demana al backend (restauració asíncrona).
+			if (key.selectedUserStoryId && key.currentScreen === 'userStoryDetail') {
+				sendMessage({ command: 'loadUserStoryByObjectId', objectId: key.selectedUserStoryId });
+			} else {
+				setSelectedUserStory(null);
+			}
+
+			// Defecte de detall: es demana al backend (restauració asíncrona).
+			if (key.selectedDefectId && key.currentScreen === 'defectDetail') {
+				sendMessage({ command: 'loadDefectByObjectId', objectId: key.selectedDefectId });
+			} else {
+				setSelectedDefect(null);
+			}
+		},
+		[iterations, loadUserStories, sendMessage]
+	);
+
+	const navigateBack = useCallback(() => {
+		const key = goBack();
+		if (key) {
+			isNavigatingViaHistoryRef.current = true;
+			applyNavKey(key);
+		}
+	}, [goBack, applyNavKey]);
+
+	const navigateForward = useCallback(() => {
+		const key = goForward();
+		if (key) {
+			isNavigatingViaHistoryRef.current = true;
+			applyNavKey(key);
+		}
+	}, [goForward, applyNavKey]);
 
 	const handleSectionChange = useCallback(
 		(section: SectionType) => {
@@ -1828,9 +1911,8 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 						};
 						logDebug(`Restoring navigation state: ${JSON.stringify(state)}`);
 
-						// Restore basic navigation state
-						if (state.activeSection) setActiveSection(state.activeSection);
-						if (state.currentScreen) setCurrentScreen(state.currentScreen);
+						// Restore sub-tabs (broader than the NavKey, which only tracks portfolio)
+						// and the fields that are not part of the browser-like history key.
 						if (state.activeSubTabBySection) {
 							setActiveSubTabBySection(prev => ({ ...prev, ...state.activeSubTabBySection }));
 						} else if (state.activeViewType) {
@@ -1841,29 +1923,24 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 						if (state.globalSearchTerm) setGlobalSearchTerm(state.globalSearchTerm);
 						if (state.homeDate) setHomeDate(new Date(state.homeDate));
 
-						// Restore selected iteration - need to find it in loaded iterations
-						if (state.selectedIterationId && iterations.length > 0) {
-							const iteration = iterations.find(i => i.objectId === state.selectedIterationId);
-							if (iteration) {
-								setSelectedIteration(iteration);
-								// Only load user stories if we're on a screen that needs them
-								if (state.currentScreen === 'userStories' || state.currentScreen === 'userStoryDetail') {
-									loadUserStories(iteration);
-								}
-							}
-						}
-
-						// Restore selected user story - only load if we're on the detail screen
-						// (otherwise the handler will auto-navigate to detail, overriding our state)
-						if (state.selectedUserStoryId && state.currentScreen === 'userStoryDetail') {
-							sendMessage({ command: 'loadUserStoryByObjectId', objectId: state.selectedUserStoryId });
-						}
-
-						// Restore selected defect - only load if we're on the detail screen
-						// (otherwise the handler will auto-navigate to detail, overriding our state)
-						if (state.selectedDefectId && state.currentScreen === 'defectDetail') {
-							sendMessage({ command: 'loadDefectByObjectId', objectId: state.selectedDefectId });
-						}
+						// Restore the main navigation (section, screen, selected item) via the
+						// same mechanism used for back/forward history navigation.
+						applyNavKey({
+							activeSection: state.activeSection ?? activeSection,
+							currentScreen: state.currentScreen ?? currentScreen,
+							selectedIterationId: state.selectedIterationId,
+							selectedUserStoryId: state.selectedUserStoryId,
+							selectedDefectId: state.selectedDefectId
+						});
+					}
+					break;
+				case 'navigateHistory':
+					// Browser-like back/forward triggered from an IDE command
+					// (robert.goBack / robert.goForward), e.g. mapped to the mouse side buttons.
+					if (message.direction === 'forward') {
+						navigateForward();
+					} else {
+						navigateBack();
 					}
 					break;
 				case 'rallyCallStarted':
@@ -1877,7 +1954,7 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 
 		window.addEventListener('message', handleMessage);
 		return () => window.removeEventListener('message', handleMessage);
-	}, [findCurrentIteration, loadUserStories, portfolioActiveViewType, currentScreen, sendMessage, loadTasks, loadIterations, loadAllDefects, loadTeamMembers, iterations, resetAllState, activeSection, handleIterationSelected]); // Only include dependencies needed by handleMessage
+	}, [findCurrentIteration, loadUserStories, portfolioActiveViewType, currentScreen, sendMessage, loadTasks, loadIterations, loadAllDefects, loadTeamMembers, iterations, resetAllState, activeSection, handleIterationSelected, applyNavKey, navigateBack, navigateForward]); // Only include dependencies needed by handleMessage
 
 	// Load velocity data from backend when on metrics (per-sprint US totals so Sprint 82 etc. show correct hours)
 	useEffect(() => {
@@ -1936,6 +2013,21 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		}, 100);
 		return () => clearTimeout(timeoutId);
 	}, [activeSection, currentScreen, portfolioActiveViewType, activeSubTabBySection, selectedIteration?.objectId, selectedUserStory?.objectId, selectedDefect?.objectId, activeUserStoryTab, globalSearchTerm, homeDate, sendMessage]);
+
+	// Push the current location onto the browser-like navigation history whenever the
+	// main navigation changes. Skips the push when the change was itself caused by a
+	// back/forward navigation (to avoid re-apilar the restored entry). Debounced so
+	// that actions mutating several setters at once produce a single history entry.
+	useEffect(() => {
+		const timeoutId = setTimeout(() => {
+			if (isNavigatingViaHistoryRef.current) {
+				isNavigatingViaHistoryRef.current = false;
+				return;
+			}
+			pushEntry(getCurrentNavKey());
+		}, 100);
+		return () => clearTimeout(timeoutId);
+	}, [activeSection, currentScreen, selectedIteration?.objectId, selectedUserStory?.objectId, selectedDefect?.objectId, getCurrentNavKey, pushEntry]);
 
 	// Track home year changes and load holidays for the new year
 	useEffect(() => {
@@ -2186,6 +2278,25 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		};
 	}, [hasVsCodeApi, sendMessage]);
 
+	// Report webview focus state to the extension so it can toggle the
+	// `robertWebviewFocused` context key. This is needed because the built-in
+	// `focusedView` context key is NOT set while focus is inside a sidebar
+	// webview's iframe, so the Alt+Left/Right keybindings can't be scoped to it
+	// otherwise. (Editor panels are covered by `activeWebviewPanelId`.)
+	useEffect(() => {
+		const reportFocus = (focused: boolean) => sendMessage({ command: 'webviewFocusChanged', focused });
+		const onFocus = () => reportFocus(true);
+		const onBlur = () => reportFocus(false);
+		window.addEventListener('focus', onFocus);
+		window.addEventListener('blur', onBlur);
+		// Report the initial state in case the webview already has focus on mount.
+		if (document.hasFocus()) reportFocus(true);
+		return () => {
+			window.removeEventListener('focus', onFocus);
+			window.removeEventListener('blur', onBlur);
+		};
+	}, [sendMessage]);
+
 	// Handle keyboard shortcut for opening search (Cmd/Ctrl+F)
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
@@ -2193,6 +2304,10 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 				event.preventDefault();
 				handleSectionChange('search');
 			}
+			// Alt+Left / Alt+Right for history back/forward are handled via VS Code
+			// keybindings (robert.goBack / robert.goForward) so they show up in the
+			// Keyboard Shortcuts editor and can be remapped. We must NOT preventDefault
+			// them here, otherwise the webview would swallow the forwarded keybinding.
 		};
 
 		document.addEventListener('keydown', handleKeyDown);
@@ -2202,39 +2317,27 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		};
 	}, [handleSectionChange]);
 
+	// Browser-like back/forward with the mouse side buttons.
+	// Button values: 0 = left, 1 = middle, 2 = right, 3 = back, 4 = forward.
+	// Registered on a single event (mousedown) to avoid firing 2-3× per click.
 	useEffect(() => {
 		const handleMouseEvent = (event: globalThis.MouseEvent) => {
-			// Mouse back button is typically button 3 (some mice use button 4)
-			// Button values: 0 = left, 1 = middle, 2 = right, 3 = back, 4 = forward
 			if (event.button === 3) {
 				event.preventDefault();
 				event.stopPropagation();
-
-				// Navigate back based on current screen
-				if (currentScreen === 'userStoryDetail' && selectedUserStory) {
-					handleBackToUserStories();
-				} else if (currentScreen === 'userStories' && selectedIteration) {
-					handleBackToIterations();
-				} else if (currentScreen === 'defectDetail' && selectedDefect) {
-					handleBackToDefects();
-				}
+				navigateBack();
+			} else if (event.button === 4) {
+				event.preventDefault();
+				event.stopPropagation();
+				navigateForward();
 			}
 		};
 
-		// Add event listeners to catch mouse events - try multiple event types
-		// Some browsers/mice may use different events
 		document.addEventListener('mousedown', handleMouseEvent);
-		document.addEventListener('mouseup', handleMouseEvent);
-		document.addEventListener('auxclick', handleMouseEvent);
-
 		return () => {
 			document.removeEventListener('mousedown', handleMouseEvent);
-			document.removeEventListener('mouseup', handleMouseEvent);
-			document.removeEventListener('auxclick', handleMouseEvent);
-			// eslint-disable-next-line no-console
-			console.log('[MainWebview] Mouse event listeners removed from document');
 		};
-	}, [currentScreen, selectedUserStory, selectedIteration, selectedDefect, handleBackToUserStories, handleBackToIterations, handleBackToDefects]);
+	}, [navigateBack, navigateForward]);
 
 	const _clearIterations = () => {
 		setIterations([]);

--- a/src/webview/hooks/useNavigationHistory.ts
+++ b/src/webview/hooks/useNavigationHistory.ts
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Subconjunt de l'estat de navegació que constitueix una entrada d'historial
+ * "estil navegador". Només inclou la navegació principal; les micro-interaccions
+ * (data del calendari, pestanya interna d'una user story, terme de cerca) queden
+ * fora expressament perquè no generin passos d'historial.
+ */
+export interface NavKey {
+	activeSection: string;
+	currentScreen: string;
+	selectedIterationId?: string;
+	selectedUserStoryId?: string;
+	selectedDefectId?: string;
+}
+
+export function sameNavKey(a: NavKey | undefined, b: NavKey | undefined): boolean {
+	if (!a || !b) return false;
+	return a.activeSection === b.activeSection && a.currentScreen === b.currentScreen && a.selectedIterationId === b.selectedIterationId && a.selectedUserStoryId === b.selectedUserStoryId && a.selectedDefectId === b.selectedDefectId;
+}
+
+/**
+ * Pila d'historial de navegació amb semàntica de navegador: push amb dedup,
+ * truncació de la branca "endavant" en navegar a un lloc nou, i back/forward.
+ *
+ * Les entrades i l'índex es mantenen tant en estat (per exposar
+ * `canGoBack`/`canGoForward` de forma reactiva) com en refs (per llegir el valor
+ * actual dins dels callbacks sense stale closures).
+ */
+export function useNavigationHistory() {
+	const entriesRef = useRef<NavKey[]>([]);
+	const indexRef = useRef<number>(-1);
+	const [canGoBack, setCanGoBack] = useState(false);
+	const [canGoForward, setCanGoForward] = useState(false);
+
+	const syncFlags = useCallback(() => {
+		setCanGoBack(indexRef.current > 0);
+		setCanGoForward(indexRef.current < entriesRef.current.length - 1);
+	}, []);
+
+	const pushEntry = useCallback(
+		(key: NavKey) => {
+			const current = entriesRef.current[indexRef.current];
+			// Dedup: no apilem si és idèntica a l'entrada actual.
+			if (sameNavKey(current, key)) return;
+
+			// Truncació: si estem al mig de la pila (hem fet back), descartem la
+			// branca cap endavant abans d'afegir la nova entrada.
+			const truncated = entriesRef.current.slice(0, indexRef.current + 1);
+			truncated.push(key);
+			entriesRef.current = truncated;
+			indexRef.current = truncated.length - 1;
+			syncFlags();
+		},
+		[syncFlags]
+	);
+
+	const goBack = useCallback((): NavKey | null => {
+		if (indexRef.current <= 0) return null;
+		indexRef.current -= 1;
+		syncFlags();
+		return entriesRef.current[indexRef.current];
+	}, [syncFlags]);
+
+	const goForward = useCallback((): NavKey | null => {
+		if (indexRef.current >= entriesRef.current.length - 1) return null;
+		indexRef.current += 1;
+		syncFlags();
+		return entriesRef.current[indexRef.current];
+	}, [syncFlags]);
+
+	return { pushEntry, goBack, goForward, canGoBack, canGoForward };
+}


### PR DESCRIPTION
Adds functionality for navigating history in the webview using 'robert.goBack' and 'robert.goForward' commands. Updates package.json to include new commands and keybindings for Alt+Left and Alt+Right. Enhances the RobertWebviewProvider to handle navigation requests, improving user experience by allowing users to navigate through their history seamlessly.