### PR TITLE
feat: enhance ScreenHeader and EntityTypeBadge components for improved entity representation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "robert",
 	"displayName": "IBM Robert",
 	"description": "For IBM internal use only.",
-	"version": "0.4.2",
+	"version": "0.5.0",
 	"type": "commonjs",
 	"icon": "resources/icons/robert-logo4.png",
 	"publisher": "trevSmart",

--- a/src/libs/rally/rallyServices.ts
+++ b/src/libs/rally/rallyServices.ts
@@ -625,6 +625,7 @@ async function formatDefectsAsync(results: any[]): Promise<RallyDefect[]> {
 			project: defect.Project ? (defect.Project._refObjectName ?? defect.Project.refObjectName) : defect.project ? (defect.project._refObjectName ?? defect.project.refObjectName) : null,
 			iteration: defect.Iteration ? (defect.Iteration._refObjectName ?? defect.Iteration.refObjectName) : defect.iteration ? (defect.iteration._refObjectName ?? defect.iteration.refObjectName) : null,
 			blocked: defect.Blocked ?? defect.blocked ?? false,
+			blockedReason: defect.BlockedReason ?? defect.blockedReason ?? null,
 			discussionCount: defect.Discussion?.Count ?? defect.discussion?.count ?? 0,
 			scheduleState: defect.ScheduleState ?? defect.scheduleState ?? 'Unknown'
 		});
@@ -676,6 +677,7 @@ async function formatUserStoriesAsync(result: RallyApiResult): Promise<RallyUser
 						: { _refObjectName: userStory.iteration }
 					: null,
 			blocked: userStory.Blocked ?? userStory.blocked,
+			blockedReason: userStory.BlockedReason ?? userStory.blockedReason ?? null,
 			taskEstimateTotal: userStory.TaskEstimateTotal ?? userStory.taskEstimateTotal,
 			taskStatus: userStory.TaskStatus ?? userStory.taskStatus,
 			scheduleState: userStory.ScheduleState ?? userStory.scheduleState ?? 'Unknown',
@@ -763,7 +765,31 @@ function addToCache(newItems: RallyUserStory[], cacheArray: RallyUserStory[], id
 function buildUserStoryQueryOptions(query: RallyQueryParams, offset: number = 0) {
 	const queryOptions: RallyQueryOptions = {
 		type: 'hierarchicalrequirement',
-		fetch: ['FormattedID', 'Name', 'Description', 'Iteration', 'Blocked', 'TaskEstimateTotal', 'ToDo', 'c_Assignee', 'Owner', 'State', 'PlanEstimate', 'TaskStatus', 'Tasks', 'TestCases', 'Defects', 'Discussion', 'ObjectID', 'c_Appgar', 'ScheduleState', 'Project', 'RevisionHistory', 'CreationDate'],
+		fetch: [
+			'FormattedID',
+			'Name',
+			'Description',
+			'Iteration',
+			'Blocked',
+			'BlockedReason',
+			'TaskEstimateTotal',
+			'ToDo',
+			'c_Assignee',
+			'Owner',
+			'State',
+			'PlanEstimate',
+			'TaskStatus',
+			'Tasks',
+			'TestCases',
+			'Defects',
+			'Discussion',
+			'ObjectID',
+			'c_Appgar',
+			'ScheduleState',
+			'Project',
+			'RevisionHistory',
+			'CreationDate'
+		],
 		order: 'FormattedID desc' // Order by FormattedID descending to get proper pagination
 	};
 
@@ -1207,7 +1233,7 @@ export async function getDefects(query: RallyQueryParams = {}, offset: number = 
 	//Si no hi ha filtres o no tenim dades suficients, anem a l'API
 	const queryOptions: RallyQueryOptions = {
 		type: 'defect',
-		fetch: ['FormattedID', 'Name', 'Description', 'State', 'Severity', 'Priority', 'Owner', 'Project', 'Iteration', 'Blocked', 'Discussion', 'ObjectID', 'ScheduleState'],
+		fetch: ['FormattedID', 'Name', 'Description', 'State', 'Severity', 'Priority', 'Owner', 'Project', 'Iteration', 'Blocked', 'BlockedReason', 'Discussion', 'ObjectID', 'ScheduleState'],
 		order: 'FormattedID desc' // Order by FormattedID descending for pagination
 	};
 
@@ -1542,7 +1568,7 @@ export async function getUserStoryDefects(userStoryId: string) {
 			// If it's just a count, we need to query defects directly by Requirement
 			const defectQueryOptions: RallyQueryOptions = {
 				type: 'defect',
-				fetch: ['FormattedID', 'Name', 'Description', 'State', 'Severity', 'Priority', 'Owner', 'Project', 'Iteration', 'Blocked', 'Discussion', 'ObjectID', 'ScheduleState'],
+				fetch: ['FormattedID', 'Name', 'Description', 'State', 'Severity', 'Priority', 'Owner', 'Project', 'Iteration', 'Blocked', 'BlockedReason', 'Discussion', 'ObjectID', 'ScheduleState'],
 				query: queryUtils.where('Requirement.ObjectID', '=', userStoryId)
 			};
 
@@ -1613,7 +1639,7 @@ export async function getUserStoryDefects(userStoryId: string) {
 
 		const defectQueryOptions: RallyQueryOptions = {
 			type: 'defect',
-			fetch: ['FormattedID', 'Name', 'Description', 'State', 'Severity', 'Priority', 'Owner', 'Project', 'Iteration', 'Blocked', 'Discussion', 'ObjectID', 'ScheduleState']
+			fetch: ['FormattedID', 'Name', 'Description', 'State', 'Severity', 'Priority', 'Owner', 'Project', 'Iteration', 'Blocked', 'BlockedReason', 'Discussion', 'ObjectID', 'ScheduleState']
 		};
 
 		if (defectQueries.length === 1) {
@@ -2650,7 +2676,31 @@ export async function getUserStoryByObjectId(objectId: string): Promise<{ userSt
 	const rallyApi = getRallyApi();
 	const queryOptions: RallyQueryOptions = {
 		type: 'hierarchicalrequirement',
-		fetch: ['FormattedID', 'Name', 'Description', 'Iteration', 'Blocked', 'TaskEstimateTotal', 'ToDo', 'c_Assignee', 'Owner', 'State', 'PlanEstimate', 'TaskStatus', 'Tasks', 'TestCases', 'Defects', 'Discussion', 'ObjectID', 'c_Appgar', 'ScheduleState', 'Project', 'RevisionHistory', 'CreationDate'],
+		fetch: [
+			'FormattedID',
+			'Name',
+			'Description',
+			'Iteration',
+			'Blocked',
+			'BlockedReason',
+			'TaskEstimateTotal',
+			'ToDo',
+			'c_Assignee',
+			'Owner',
+			'State',
+			'PlanEstimate',
+			'TaskStatus',
+			'Tasks',
+			'TestCases',
+			'Defects',
+			'Discussion',
+			'ObjectID',
+			'c_Appgar',
+			'ScheduleState',
+			'Project',
+			'RevisionHistory',
+			'CreationDate'
+		],
 		query: queryUtils.where('ObjectID', '=', objectId)
 	};
 
@@ -2680,7 +2730,7 @@ export async function getDefectByObjectId(objectId: string): Promise<{ defect: R
 		rallyApi,
 		{
 			type: 'defect',
-			fetch: ['FormattedID', 'Name', 'Description', 'State', 'Severity', 'Priority', 'Owner', 'Project', 'Iteration', 'Blocked', 'Discussion', 'ObjectID', 'ScheduleState'],
+			fetch: ['FormattedID', 'Name', 'Description', 'State', 'Severity', 'Priority', 'Owner', 'Project', 'Iteration', 'Blocked', 'BlockedReason', 'Discussion', 'ObjectID', 'ScheduleState'],
 			query: queryUtils.where('ObjectID', '=', objectId)
 		},
 		'Loading defect...'

--- a/src/types/rally.d.ts
+++ b/src/types/rally.d.ts
@@ -19,6 +19,7 @@ export interface UserStory {
 	project: string | null;
 	iteration: string | IterationRef | null;
 	blocked: boolean;
+	blockedReason?: string | null; // Rally BlockedReason - motiu del bloqueig quan blocked=true
 	taskEstimateTotal: number;
 	taskStatus?: string; // Deprecated - use scheduleState instead
 	tasksCount: number;
@@ -64,6 +65,7 @@ export interface Defect {
 	iteration: string | null;
 	scheduleState: string; // PRIMARY: Rally ScheduleState (Defined, In-Progress, Completed, New)
 	blocked: boolean;
+	blockedReason?: string | null; // Rally BlockedReason - motiu del bloqueig quan blocked=true
 	discussionCount: number;
 	_ref?: string;
 }

--- a/src/webview/components/MainWebview.tsx
+++ b/src/webview/components/MainWebview.tsx
@@ -200,7 +200,7 @@ const BySprintsView: FC<PortfolioViewProps> = ({
 
 			{currentScreen === 'userStoryDetail' && selectedUserStory && (
 				<>
-					<ScreenHeader title={`User story "${selectedUserStory.formattedId}: ${selectedUserStory.name}"`} showBackButton={true} onBack={onBackToUserStories} titleActions={<OpenInRallyButton objectId={selectedUserStory.objectId} />} />
+					<ScreenHeader entityType="userstory" title={`${selectedUserStory.formattedId}: ${selectedUserStory.name}`} showBackButton={true} onBack={onBackToUserStories} titleActions={<OpenInRallyButton objectId={selectedUserStory.objectId} />} />
 					<UserStoryForm userStory={selectedUserStory} selectedAdditionalTab={activeUserStoryTab} onAdditionalTabChange={onActiveUserStoryTabChange} additionalTabContent={additionalTabContent} iterations={iterations} />
 				</>
 			)}
@@ -282,7 +282,7 @@ const AllUserStoriesView: FC<PortfolioViewProps> = ({
 
 			{currentScreen === 'userStoryDetail' && selectedUserStory && (
 				<>
-					<ScreenHeader title={`User story "${selectedUserStory.formattedId}: ${selectedUserStory.name}"`} showBackButton={true} onBack={onBackToUserStories} titleActions={<OpenInRallyButton objectId={selectedUserStory.objectId} />} />
+					<ScreenHeader entityType="userstory" title={`${selectedUserStory.formattedId}: ${selectedUserStory.name}`} showBackButton={true} onBack={onBackToUserStories} titleActions={<OpenInRallyButton objectId={selectedUserStory.objectId} />} />
 					<UserStoryForm userStory={selectedUserStory} selectedAdditionalTab={activeUserStoryTab} onAdditionalTabChange={onActiveUserStoryTabChange} additionalTabContent={additionalTabContent} iterations={iterations} />
 				</>
 			)}
@@ -312,7 +312,7 @@ const AllDefectsView: FC<PortfolioViewProps> = ({ _defects, _defectsLoading, _de
 			)}
 			{currentScreen === 'defectDetail' && _selectedDefect && (
 				<>
-					<ScreenHeader title={`Defect "${_selectedDefect.formattedId}: ${_selectedDefect.name}"`} showBackButton={true} onBack={_onBackToDefects} />
+					<ScreenHeader entityType="defect" title={`${_selectedDefect.formattedId}: ${_selectedDefect.name}`} showBackButton={true} onBack={_onBackToDefects} />
 					<DefectForm defect={_selectedDefect as Defect} />
 				</>
 			)}

--- a/src/webview/components/MainWebview.tsx
+++ b/src/webview/components/MainWebview.tsx
@@ -488,10 +488,13 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 	const { wrapperRef, contentRef } = useSmoothScroll(hasVsCodeApi);
 
 	// Pila d'historial de navegació estil navegador (back/forward amb ratolí i teclat).
-	const { pushEntry, peekBack, goBack, goForward } = useNavigationHistory();
+	const { pushEntry, replaceEntry, peekBack, goBack, goForward } = useNavigationHistory();
 	// Es posa a true mentre apliquem una entrada d'historial, perquè l'effect de push
 	// no torni a apilar el canvi d'estat que provoca la pròpia navegació back/forward.
 	const isNavigatingViaHistoryRef = useRef(false);
+	// La fletxa enrere ha tancat un detall sense cap entrada anterior on tornar: el
+	// proper snapshot ha de substituir l'entrada del detall, no apilar-se al damunt.
+	const isReplacingHistoryEntryRef = useRef(false);
 
 	const sendMessage = useCallback(
 		(command: string | Record<string, unknown>, data?: any) => {
@@ -990,6 +993,9 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 
 	const handleIterationClickFromHome = useCallback(
 		(iteration: Iteration) => {
+			// El calendari de la Home també obre el detall dins de Portfolio, així que
+			// la fletxa enrere ha de tornar a Home igual que des de Favorits/Recents.
+			detailOriginSectionRef.current = 'home';
 			setActiveSection('portfolio');
 			handleIterationSelected(iteration);
 		},
@@ -1166,6 +1172,10 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		if (peekBack()?.activeSection === 'home') {
 			navigateBack();
 		} else {
+			// Sense entrada de Home al darrere (p. ex. el detall va arribar dins la
+			// finestra de debounce del primer push): substituïm l'entrada del detall
+			// en comptes d'apilar-ne una, o quedaria a la branca "endavant".
+			isReplacingHistoryEntryRef.current = true;
 			setActiveSection('home');
 		}
 		return true;
@@ -2066,10 +2076,15 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 				isNavigatingViaHistoryRef.current = false;
 				return;
 			}
+			if (isReplacingHistoryEntryRef.current) {
+				isReplacingHistoryEntryRef.current = false;
+				replaceEntry(getCurrentNavKey());
+				return;
+			}
 			pushEntry(getCurrentNavKey());
 		}, 100);
 		return () => clearTimeout(timeoutId);
-	}, [activeSection, currentScreen, selectedIteration?.objectId, selectedUserStory?.objectId, selectedDefect?.objectId, getCurrentNavKey, pushEntry]);
+	}, [activeSection, currentScreen, selectedIteration?.objectId, selectedUserStory?.objectId, selectedDefect?.objectId, getCurrentNavKey, pushEntry, replaceEntry]);
 
 	// Track home year changes and load holidays for the new year
 	useEffect(() => {

--- a/src/webview/components/MainWebview.tsx
+++ b/src/webview/components/MainWebview.tsx
@@ -488,7 +488,7 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 	const { wrapperRef, contentRef } = useSmoothScroll(hasVsCodeApi);
 
 	// Pila d'historial de navegació estil navegador (back/forward amb ratolí i teclat).
-	const { pushEntry, goBack, goForward } = useNavigationHistory();
+	const { pushEntry, peekBack, goBack, goForward } = useNavigationHistory();
 	// Es posa a true mentre apliquem una entrada d'historial, perquè l'effect de push
 	// no torni a apilar el canvi d'estat que provoca la pròpia navegació back/forward.
 	const isNavigatingViaHistoryRef = useRef(false);
@@ -922,16 +922,6 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		[sendMessage]
 	);
 
-	const handleBackToDefects = useCallback(() => {
-		setSelectedDefect(null);
-		setCurrentScreen('defects');
-		// Opened from the Home lists: the detail renders inside Portfolio, but back belongs to Home.
-		if (detailOriginSectionRef.current === 'home') {
-			detailOriginSectionRef.current = null;
-			setActiveSection('home');
-		}
-	}, []);
-
 	const switchViewType = useCallback(
 		(newViewType: PortfolioViewType) => {
 			// State cleaners for each view type (only clear when necessary)
@@ -1083,45 +1073,6 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		[loadTasks, wrapperRef, sendMessage]
 	);
 
-	const handleBackToIterations = useCallback(() => {
-		setCurrentScreen('iterations');
-		setSelectedIteration(null);
-		setSelectedUserStory(null);
-		setUserStories([]);
-		if (detailOriginSectionRef.current === 'home') {
-			detailOriginSectionRef.current = null;
-			setActiveSection('home');
-		}
-	}, []);
-
-	const handleBackToUserStories = useCallback(() => {
-		// Depenent de la vista activa, tornem a la pantalla correcta
-		if (portfolioActiveViewType === 'allUserStories') {
-			setCurrentScreen('allUserStories');
-		} else {
-			setCurrentScreen('userStories');
-		}
-		setSelectedUserStory(null);
-		setTasks([]);
-		setTasksError(null);
-		setUserStoryDefects([]);
-		setUserStoryDefectsError(null);
-		setUserStoryDiscussions([]);
-		setUserStoryDiscussionsError(null);
-		setUserStoryTestCases([]);
-		setUserStoryTestCasesError(null);
-		setActiveUserStoryTab('tasks');
-		// Clear the attempted tracking when going back
-		attemptedUserStoryDefects.current.clear();
-		attemptedUserStoryDiscussions.current.clear();
-		attemptedUserStoryTests.current.clear();
-		// Opened from the Home lists: the detail renders inside Portfolio, but back belongs to Home.
-		if (detailOriginSectionRef.current === 'home') {
-			detailOriginSectionRef.current = null;
-			setActiveSection('home');
-		}
-	}, [portfolioActiveViewType]);
-
 	// Snapshot de la navegació principal actual (per apilar a l'historial).
 	// El subtab del portfolio NO forma part de la clau: ja queda determinat pel
 	// currentScreen, i incloure'l provocaria falsos passos d'historial quan la
@@ -1204,6 +1155,59 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 			applyNavKey(key);
 		}
 	}, [goForward, applyNavKey]);
+
+	// La fletxa enrere d'un detall obert des de la Home ha de CONSUMIR l'entrada
+	// d'historial del detall, no apilar-ne una de nova: si no, Alt+Left ens tornaria
+	// al detall que acabem de tancar. Deleguem a `navigateBack` perquè restaura
+	// l'entrada exacta d'on veníem; només si l'historial no la té reconstruïm l'estat.
+	const returnToHomeOrigin = useCallback((): boolean => {
+		if (detailOriginSectionRef.current !== 'home') return false;
+		detailOriginSectionRef.current = null;
+		if (peekBack()?.activeSection === 'home') {
+			navigateBack();
+		} else {
+			setActiveSection('home');
+		}
+		return true;
+	}, [peekBack, navigateBack]);
+
+	const handleBackToIterations = useCallback(() => {
+		setCurrentScreen('iterations');
+		setSelectedIteration(null);
+		setSelectedUserStory(null);
+		setUserStories([]);
+		returnToHomeOrigin();
+	}, [returnToHomeOrigin]);
+
+	const handleBackToDefects = useCallback(() => {
+		setSelectedDefect(null);
+		setCurrentScreen('defects');
+		returnToHomeOrigin();
+	}, [returnToHomeOrigin]);
+
+	const handleBackToUserStories = useCallback(() => {
+		// Depenent de la vista activa, tornem a la pantalla correcta
+		if (portfolioActiveViewType === 'allUserStories') {
+			setCurrentScreen('allUserStories');
+		} else {
+			setCurrentScreen('userStories');
+		}
+		setSelectedUserStory(null);
+		setTasks([]);
+		setTasksError(null);
+		setUserStoryDefects([]);
+		setUserStoryDefectsError(null);
+		setUserStoryDiscussions([]);
+		setUserStoryDiscussionsError(null);
+		setUserStoryTestCases([]);
+		setUserStoryTestCasesError(null);
+		setActiveUserStoryTab('tasks');
+		// Clear the attempted tracking when going back
+		attemptedUserStoryDefects.current.clear();
+		attemptedUserStoryDiscussions.current.clear();
+		attemptedUserStoryTests.current.clear();
+		returnToHomeOrigin();
+	}, [portfolioActiveViewType, returnToHomeOrigin]);
 
 	const handleSectionChange = useCallback(
 		(section: SectionType) => {
@@ -1681,8 +1685,10 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 							setPortfolioUserStoriesHasMore(message.hasMore || false);
 							setPortfolioUserStoriesOffset((message.offset || 0) + (message.userStories?.length || 0));
 							setUserStoriesError(null);
-							// Assegura que la pantalla es correcta quan es carreguen totes les user stories
-							if (portfolioActiveViewType === 'allUserStories' && currentScreen !== 'userStoryDetail') {
+							// Assegura que la pantalla es correcta quan es carreguen totes les user stories.
+							// Només dins de portfolio: la Home també carrega user stories (Calendar) i
+							// canviar-li currentScreen provocaria una segona transició després d'aterrar-hi.
+							if (activeSection === 'portfolio' && portfolioActiveViewType === 'allUserStories' && currentScreen !== 'userStoryDetail') {
 								setCurrentScreen('allUserStories');
 							}
 						}
@@ -1748,7 +1754,7 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 						setDefectsError(null);
 						// Only navigate to defects list if we're not in detail view
 						// Don't override defectDetail when coming from search
-						if (portfolioActiveViewType === 'allDefects' && currentScreen !== 'defects' && currentScreen !== 'defectDetail') {
+						if (activeSection === 'portfolio' && portfolioActiveViewType === 'allDefects' && currentScreen !== 'defects' && currentScreen !== 'defectDetail') {
 							setCurrentScreen('defects');
 						}
 					} else {

--- a/src/webview/components/MainWebview.tsx
+++ b/src/webview/components/MainWebview.tsx
@@ -649,6 +649,9 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 	// Ref for search input to focus when search tab is selected
 	const searchInputRef = useRef<HTMLInputElement>(null);
 	const previousSectionBeforeSearchRef = useRef<SectionType>('home');
+	// Records that the current detail screen was opened from the Home lists, so
+	// the back arrow returns to Home instead of the Portfolio list the detail renders in.
+	const detailOriginSectionRef = useRef<SectionType | null>(null);
 
 	// Navigation state
 	const [activeSection, setActiveSection] = useState<SectionType>('home');
@@ -768,6 +771,7 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 
 	const openSearchResult = useCallback(
 		(item: GlobalSearchResultItem) => {
+			detailOriginSectionRef.current = null;
 			if (item.entityType === 'userstory') {
 				pendingSearchUserStoryTabRef.current = null;
 				sendMessage({ command: 'loadUserStoryByObjectId', objectId: item.objectId });
@@ -907,6 +911,7 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 
 	const handleDefectSelected = useCallback(
 		(defect: RallyDefect) => {
+			detailOriginSectionRef.current = null;
 			setSelectedDefect(defect);
 			setCurrentScreen('defectDetail');
 			sendMessage({
@@ -920,6 +925,11 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 	const handleBackToDefects = useCallback(() => {
 		setSelectedDefect(null);
 		setCurrentScreen('defects');
+		// Opened from the Home lists: the detail renders inside Portfolio, but back belongs to Home.
+		if (detailOriginSectionRef.current === 'home') {
+			detailOriginSectionRef.current = null;
+			setActiveSection('home');
+		}
 	}, []);
 
 	const switchViewType = useCallback(
@@ -996,9 +1006,18 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		[handleIterationSelected]
 	);
 
+	const handleIterationSelectedFromPortfolio = useCallback(
+		(iteration: Iteration) => {
+			detailOriginSectionRef.current = null;
+			handleIterationSelected(iteration);
+		},
+		[handleIterationSelected]
+	);
+
 	// Shared navigation for both the Recently Viewed and Favorites lists — same record kinds.
 	const navigateToItem = useCallback(
 		(item: RallyItemRef) => {
+			detailOriginSectionRef.current = 'home';
 			switch (item.type) {
 				case 'userstory':
 					sendMessage({ command: 'loadUserStoryByObjectId', objectId: item.objectId });
@@ -1050,6 +1069,7 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 
 	const handleUserStorySelected = useCallback(
 		(userStory: UserStory) => {
+			detailOriginSectionRef.current = null;
 			setSelectedUserStory(userStory);
 			setCurrentScreen('userStoryDetail');
 			setActiveUserStoryTab('tasks');
@@ -1068,6 +1088,10 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		setSelectedIteration(null);
 		setSelectedUserStory(null);
 		setUserStories([]);
+		if (detailOriginSectionRef.current === 'home') {
+			detailOriginSectionRef.current = null;
+			setActiveSection('home');
+		}
 	}, []);
 
 	const handleBackToUserStories = useCallback(() => {
@@ -1091,6 +1115,11 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 		attemptedUserStoryDefects.current.clear();
 		attemptedUserStoryDiscussions.current.clear();
 		attemptedUserStoryTests.current.clear();
+		// Opened from the Home lists: the detail renders inside Portfolio, but back belongs to Home.
+		if (detailOriginSectionRef.current === 'home') {
+			detailOriginSectionRef.current = null;
+			setActiveSection('home');
+		}
 	}, [portfolioActiveViewType]);
 
 	// Snapshot de la navegació principal actual (per apilar a l'historial).
@@ -1112,6 +1141,8 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 	// que el case 'restoreState' (inclosa la càrrega asíncrona d'items de detall).
 	const applyNavKey = useCallback(
 		(key: NavKey) => {
+			// The history entry carries its own section, so any pending Home origin no longer applies.
+			detailOriginSectionRef.current = null;
 			setActiveSection(key.activeSection as SectionType);
 			setCurrentScreen(key.currentScreen as ScreenType);
 
@@ -2571,7 +2602,7 @@ const MainWebview: FC<MainWebviewProps> = ({ webviewId, context, _rebusLogoUri, 
 													activeUserStoryTab={activeUserStoryTab}
 													currentScreen={renderedScreen}
 													onLoadIterations={loadIterations}
-													onIterationSelected={handleIterationSelected}
+													onIterationSelected={handleIterationSelectedFromPortfolio}
 													onUserStorySelected={handleUserStorySelected}
 													onLoadUserStories={loadUserStories}
 													onClearUserStories={clearUserStories}

--- a/src/webview/components/common/BlockedReasonBanner.tsx
+++ b/src/webview/components/common/BlockedReasonBanner.tsx
@@ -1,0 +1,51 @@
+import { FC } from 'react';
+import styled from 'styled-components';
+
+const Banner = styled.div`
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	padding: 8px 10px;
+	border-radius: 6px;
+	background: color(srgb 0.75 0.2 0.2 / 0.12);
+	border: 1px solid color(srgb 0.75 0.2 0.2 / 0.3);
+	color: var(--vscode-foreground);
+	font-size: 12px;
+	line-height: 1.45;
+`;
+
+const Label = styled.span`
+	flex-shrink: 0;
+	font-weight: 500;
+	color: color(srgb 0.82 0.32 0.32 / 1);
+`;
+
+const Reason = styled.span`
+	white-space: pre-wrap;
+	word-break: break-word;
+`;
+
+interface BlockedReasonBannerProps {
+	blocked: boolean;
+	blockedReason?: string | null;
+}
+
+/**
+ * Mostra el motiu del bloqueig (camp BlockedReason de Rally).
+ * No renderitza res si l'item no està bloquejat o no té motiu informat.
+ */
+const BlockedReasonBanner: FC<BlockedReasonBannerProps> = ({ blocked, blockedReason }) => {
+	const reason = blockedReason?.trim();
+	if (!blocked || !reason) {
+		return null;
+	}
+
+	return (
+		<Banner>
+			<Label>Blocked reason:</Label>
+			<Reason>{reason}</Reason>
+		</Banner>
+	);
+};
+
+export default BlockedReasonBanner;

--- a/src/webview/components/common/DefectForm.tsx
+++ b/src/webview/components/common/DefectForm.tsx
@@ -1,32 +1,23 @@
 import { FC } from 'react';
-import DOMPurify from 'dompurify';
 import styled from 'styled-components';
 import { AvatarFormField } from './Avatar';
 import { isLightTheme, getScheduleStateColor as getThemeScheduleStateColor } from '../../utils/themeColors';
+import ResizableDescription from './ResizableDescription';
+import './CollapsibleCard';
 
 const StatusPill = styled.div<{ isBlocked: boolean }>`
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	min-height: 24px;
-	padding: 0 8px;
-	border-radius: 999px;
+	min-height: 20px;
+	padding: 1px 8px;
+	border-radius: 6px;
 	font-size: 11px;
 	font-weight: 500;
 	letter-spacing: 0.2px;
-	background: ${props => (props.isBlocked ? 'color(srgb 0.85 0.25 0.25 / 0.25)' : 'color(srgb 0.2 0.6 0.35 / 0.25)')};
-	color: ${props => (props.isBlocked ? 'color(srgb 0.9 0.2 0.2 / 1)' : 'color(srgb 0.2 0.75 0.45 / 1)')};
-	border: 1px solid ${props => (props.isBlocked ? 'color(srgb 0.85 0.25 0.25 / 0.45)' : 'color(srgb 0.2 0.6 0.35 / 0.45)')};
-`;
-
-// Reset outer margins of the rendered HTML so text starts flush with the padding.
-const DescriptionBody = styled.div`
-	& > :first-child {
-		margin-top: 0;
-	}
-	& > :last-child {
-		margin-bottom: 0;
-	}
+	background: ${props => (props.isBlocked ? 'color(srgb 0.75 0.2 0.2 / 0.15)' : 'color(srgb 0.15 0.55 0.3 / 0.15)')};
+	color: ${props => (props.isBlocked ? 'color(srgb 0.82 0.32 0.32 / 1)' : 'color(srgb 0.28 0.72 0.46 / 1)')};
+	border: 1px solid ${props => (props.isBlocked ? 'color(srgb 0.75 0.2 0.2 / 0.35)' : 'color(srgb 0.15 0.55 0.3 / 0.35)')};
 `;
 
 interface Defect {
@@ -78,7 +69,21 @@ const DefectForm: FC<DefectFormProps> = ({ defect }) => {
 
 	return (
 		<>
-			<collapsible-card title={`${defect.formattedId}: ${defect.name}`}>
+			<collapsible-card title="Details">
+				<div slot="header-actions" style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap', marginLeft: '12px' }}>
+					{defect.scheduleState && (
+						<div
+							style={{
+								fontSize: '13px',
+								fontWeight: '300',
+								color: getScheduleStateColor(defect.scheduleState)
+							}}
+						>
+							{defect.scheduleState}
+						</div>
+					)}
+					<StatusPill isBlocked={defect.blocked}>{defect.blocked ? 'Blocked' : 'Not Blocked'}</StatusPill>
+				</div>
 				<div
 					style={{
 						padding: '20px',
@@ -87,26 +92,6 @@ const DefectForm: FC<DefectFormProps> = ({ defect }) => {
 						gap: '20px'
 					}}
 				>
-					<div
-						style={{
-							display: 'flex',
-							justifyContent: 'space-between',
-							alignItems: 'center'
-						}}
-					>
-						{defect.scheduleState && (
-							<div
-								style={{
-									fontSize: '14px',
-									fontWeight: '400',
-									color: getScheduleStateColor(defect.scheduleState)
-								}}
-							>
-								{defect.scheduleState}
-							</div>
-						)}
-					</div>
-
 					<div style={{ marginBottom: '0px' }}>
 						<label style={{ display: 'block', marginBottom: '4px', fontSize: '12px', color: 'var(--vscode-descriptionForeground)' }}>Name</label>
 						<input
@@ -216,33 +201,11 @@ const DefectForm: FC<DefectFormProps> = ({ defect }) => {
 							/>
 						</div>
 
-						<div>
-							<label style={{ display: 'block', marginBottom: '4px', fontSize: '12px', color: 'var(--vscode-descriptionForeground)' }}>Blocked</label>
-							<StatusPill isBlocked={defect.blocked}>{defect.blocked ? 'Blocked' : 'Not Blocked'}</StatusPill>
-						</div>
-
 						{/* Description */}
 						<div style={{ display: 'flex', flexDirection: 'column', gap: '10px', gridColumn: '1 / -1' }}>
 							<h3 style={{ margin: '18px 0 3px 0', color: 'var(--vscode-foreground)', fontSize: '14px' }}>Description</h3>
 
-							<DescriptionBody
-								dangerouslySetInnerHTML={{
-									__html: defect.description ? DOMPurify.sanitize(defect.description, { FORBID_ATTR: ['style'] }) : '<p style="color: var(--vscode-descriptionForeground); font-style: italic;">No description available</p>'
-								}}
-								style={{
-									width: '100%',
-									padding: '10px 12px',
-									backgroundColor: 'color-mix(in srgb, var(--vscode-input-background) 60%, var(--vscode-panel-background))',
-									color: 'var(--vscode-input-foreground)',
-									border: '1px solid var(--vscode-input-border)',
-									borderRadius: '3px',
-									fontSize: '13px',
-									fontFamily: "'Inter', var(--vscode-font-family), -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-									lineHeight: '1.6',
-									minHeight: '120px',
-									overflow: 'auto'
-								}}
-							/>
+							<ResizableDescription description={defect.description} />
 						</div>
 					</div>
 				</div>

--- a/src/webview/components/common/DefectForm.tsx
+++ b/src/webview/components/common/DefectForm.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import styled from 'styled-components';
 import { AvatarFormField } from './Avatar';
+import { EntityRefFormField } from './EntityTypeBadge';
 import { isLightTheme, getScheduleStateColor as getThemeScheduleStateColor } from '../../utils/themeColors';
 import BlockedReasonBanner from './BlockedReasonBanner';
 import ResizableDescription from './ResizableDescription';
@@ -191,20 +192,7 @@ const DefectForm: FC<DefectFormProps> = ({ defect }) => {
 
 						<div>
 							<label style={{ display: 'block', marginBottom: '4px', fontSize: '12px', color: 'var(--vscode-descriptionForeground)' }}>Sprint</label>
-							<input
-								type="text"
-								value={defect.iteration || 'N/A'}
-								readOnly
-								style={{
-									width: '100%',
-									padding: '6px 8px',
-									backgroundColor: 'var(--vscode-input-background)',
-									color: 'var(--vscode-input-foreground)',
-									border: '1px solid var(--vscode-input-border)',
-									borderRadius: '3px',
-									fontSize: '13px'
-								}}
-							/>
+							<EntityRefFormField type="sprint" value={defect.iteration} emptyLabel="N/A" />
 						</div>
 
 						{/* Description */}

--- a/src/webview/components/common/DefectForm.tsx
+++ b/src/webview/components/common/DefectForm.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import styled from 'styled-components';
 import { AvatarFormField } from './Avatar';
 import { isLightTheme, getScheduleStateColor as getThemeScheduleStateColor } from '../../utils/themeColors';
+import BlockedReasonBanner from './BlockedReasonBanner';
 import ResizableDescription from './ResizableDescription';
 import './CollapsibleCard';
 
@@ -33,6 +34,7 @@ interface Defect {
 	project: string | null;
 	iteration: string | null;
 	blocked: boolean;
+	blockedReason?: string | null;
 	discussionCount: number;
 	environment?: string;
 	foundInBuild?: string;
@@ -82,7 +84,9 @@ const DefectForm: FC<DefectFormProps> = ({ defect }) => {
 							{defect.scheduleState}
 						</div>
 					)}
-					<StatusPill isBlocked={defect.blocked}>{defect.blocked ? 'Blocked' : 'Not Blocked'}</StatusPill>
+					<StatusPill isBlocked={defect.blocked} title={defect.blocked ? (defect.blockedReason ?? undefined) : undefined}>
+						{defect.blocked ? 'Blocked' : 'Not Blocked'}
+					</StatusPill>
 				</div>
 				<div
 					style={{
@@ -92,6 +96,8 @@ const DefectForm: FC<DefectFormProps> = ({ defect }) => {
 						gap: '20px'
 					}}
 				>
+					{defect.blocked && defect.blockedReason && <BlockedReasonBanner blocked={defect.blocked} blockedReason={defect.blockedReason} />}
+
 					<div style={{ marginBottom: '0px' }}>
 						<label style={{ display: 'block', marginBottom: '4px', fontSize: '12px', color: 'var(--vscode-descriptionForeground)' }}>Name</label>
 						<input

--- a/src/webview/components/common/EntityTypeBadge.tsx
+++ b/src/webview/components/common/EntityTypeBadge.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { UserStoryTypeIcon, DefectTypeIcon, SprintTypeIcon, TaskTypeIcon, TestCaseTypeIcon } from './icons/EntityTypeIcons';
+import { UserStoryTypeIcon, DefectTypeIcon, SprintTypeIcon, TaskTypeIcon, TestCaseTypeIcon, type EntityTypeIconProps } from './icons/EntityTypeIcons';
 import { getEntityTypeColors } from '../../utils/themeColors';
 import type { RallyEntityType } from '../../../types/rally';
 
@@ -11,7 +11,7 @@ const TYPE_LABELS: Record<RallyEntityType, string> = {
 	testcase: 'Test Case'
 };
 
-const TYPE_ICONS: Record<RallyEntityType, FC> = {
+const TYPE_ICONS: Record<RallyEntityType, FC<EntityTypeIconProps>> = {
 	userstory: UserStoryTypeIcon,
 	defect: DefectTypeIcon,
 	sprint: SprintTypeIcon,
@@ -25,17 +25,22 @@ interface EntityTypeBadgeProps {
 	type: RallyEntityType;
 	/** 'full' (icon + label, default), 'text' (label only) or 'icon' (icon only). */
 	display?: EntityTypeBadgeDisplay;
+	/** Encongeix el badge a 18px per encabir-lo en camps de formulari sense fer-los créixer. */
+	compact?: boolean;
 }
 
 /**
  * Type badge shown on Rally item rows — Recently Viewed, Favorites and global search results
  * all render it, so the three surfaces stay visually identical.
  */
-const EntityTypeBadge: FC<EntityTypeBadgeProps> = ({ type, display = 'full' }) => {
+const EntityTypeBadge: FC<EntityTypeBadgeProps> = ({ type, display = 'full', compact = false }) => {
 	const Icon = TYPE_ICONS[type];
 	const label = TYPE_LABELS[type];
 	const iconOnly = display === 'icon';
 	const colors = getEntityTypeColors(type);
+	// 12px d'icona + 1px de padding + 1px de vora a cada costat = 16px, prou petit perquè el
+	// badge no faci créixer el camp de formulari respecte de l'input que hi havia abans.
+	const iconSize = compact ? 12 : 14;
 
 	return (
 		<span
@@ -44,8 +49,8 @@ const EntityTypeBadge: FC<EntityTypeBadgeProps> = ({ type, display = 'full' }) =
 			style={{
 				fontSize: '11.5px',
 				fontWeight: 300,
-				padding: iconOnly ? '5px' : '5px 6px',
-				borderRadius: '8px',
+				padding: iconOnly ? (compact ? '1px' : '5px') : '5px 6px',
+				borderRadius: compact ? '5px' : '8px',
 				backgroundColor: colors.background,
 				color: 'var(--vscode-descriptionForeground)',
 				border: `1px solid ${colors.border}`,
@@ -56,10 +61,48 @@ const EntityTypeBadge: FC<EntityTypeBadgeProps> = ({ type, display = 'full' }) =
 				whiteSpace: 'nowrap'
 			}}
 		>
-			{display !== 'text' && <Icon />}
+			{display !== 'text' && <Icon size={iconSize} />}
 			{!iconOnly && label}
 		</span>
 	);
 };
 
 export default EntityTypeBadge;
+
+interface EntityRefFormFieldProps {
+	/** Tipus de l'entitat referenciada — determina la icona i el color del badge. */
+	type: RallyEntityType;
+	/** Nom del registre referenciat; buit mostra `emptyLabel`. */
+	value?: string | null;
+	emptyLabel?: string;
+}
+
+/**
+ * Camp de detall de només lectura per a una referència a un altre registre. Fa el mateix paper
+ * que `AvatarFormField` per a les persones: el badge del tipus encapçala el valor perquè es vegi
+ * d'un cop d'ull a quina mena de registre apunta el camp.
+ */
+export const EntityRefFormField: FC<EntityRefFormFieldProps> = ({ type, value, emptyLabel = 'N/A' }) => {
+	const empty = !value || !value.trim();
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: '8px',
+				width: '100%',
+				padding: '6px 8px',
+				backgroundColor: 'var(--vscode-input-background)',
+				border: '1px solid var(--vscode-input-border)',
+				borderRadius: '3px',
+				fontSize: '13px',
+				color: empty ? '#6c757d' : 'var(--vscode-input-foreground)',
+				boxSizing: 'border-box'
+			}}
+		>
+			<EntityTypeBadge type={type} display="icon" compact />
+			<span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{empty ? emptyLabel : value}</span>
+		</div>
+	);
+};

--- a/src/webview/components/common/EntityTypeBadge.tsx
+++ b/src/webview/components/common/EntityTypeBadge.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { UserStoryTypeIcon, DefectTypeIcon, SprintTypeIcon, TaskTypeIcon, TestCaseTypeIcon } from './icons/EntityTypeIcons';
+import { getEntityTypeColors } from '../../utils/themeColors';
 import type { RallyEntityType } from '../../../types/rally';
 
 const TYPE_LABELS: Record<RallyEntityType, string> = {
@@ -34,6 +35,7 @@ const EntityTypeBadge: FC<EntityTypeBadgeProps> = ({ type, display = 'full' }) =
 	const Icon = TYPE_ICONS[type];
 	const label = TYPE_LABELS[type];
 	const iconOnly = display === 'icon';
+	const colors = getEntityTypeColors(type);
 
 	return (
 		<span
@@ -44,9 +46,9 @@ const EntityTypeBadge: FC<EntityTypeBadgeProps> = ({ type, display = 'full' }) =
 				fontWeight: 300,
 				padding: iconOnly ? '5px' : '5px 6px',
 				borderRadius: '8px',
-				backgroundColor: 'rgba(128, 128, 128, 0.1)',
+				backgroundColor: colors.background,
 				color: 'var(--vscode-descriptionForeground)',
-				border: '1px solid var(--vscode-panel-border)',
+				border: `1px solid ${colors.border}`,
 				display: 'inline-flex',
 				alignItems: 'center',
 				gap: iconOnly ? 0 : '7px',

--- a/src/webview/components/common/ResizableDescription.tsx
+++ b/src/webview/components/common/ResizableDescription.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import DOMPurify from 'dompurify';
 
@@ -30,6 +30,10 @@ interface ResizableDescriptionProps {
 const ResizableDescription: FC<ResizableDescriptionProps> = ({ description, initialHeight = DESCRIPTION_HEIGHT_DEFAULT }) => {
 	const [height, setHeight] = useState(initialHeight);
 	const resizeStartRef = useRef({ y: 0, height: 0 });
+	// Neteja del drag actiu. Viu en un ref perquè el desmuntatge també la pugui
+	// executar: el canvi de pantalla remunta l'arbre sencer, i sense això els
+	// listeners de `document` i el cursor/userSelect del body quedarien enganxats.
+	const endResizeRef = useRef<(() => void) | null>(null);
 
 	const handleResizeStart = useCallback(
 		(e: React.MouseEvent) => {
@@ -42,17 +46,21 @@ const ResizableDescription: FC<ResizableDescriptionProps> = ({ description, init
 				const newHeight = Math.min(DESCRIPTION_HEIGHT_MAX, Math.max(DESCRIPTION_HEIGHT_MIN, resizeStartRef.current.height + delta));
 				setHeight(newHeight);
 			};
-			const onMouseUp = () => {
+			const onMouseUp = () => endResizeRef.current?.();
+			endResizeRef.current = () => {
 				document.removeEventListener('mousemove', onMouseMove);
 				document.removeEventListener('mouseup', onMouseUp);
 				document.body.style.cursor = '';
 				document.body.style.userSelect = '';
+				endResizeRef.current = null;
 			};
 			document.addEventListener('mousemove', onMouseMove);
 			document.addEventListener('mouseup', onMouseUp);
 		},
 		[height]
 	);
+
+	useEffect(() => () => endResizeRef.current?.(), []);
 
 	const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
 		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {

--- a/src/webview/components/common/ResizableDescription.tsx
+++ b/src/webview/components/common/ResizableDescription.tsx
@@ -1,0 +1,123 @@
+import { FC, useCallback, useRef, useState } from 'react';
+import styled from 'styled-components';
+import DOMPurify from 'dompurify';
+
+// Shared sizing criteria for every description panel (user stories, defects, ...).
+// MIN: the panel never collapses, even with an empty description.
+// DEFAULT: initial visible height; longer content scrolls inside the panel.
+// MAX: upper bound when the user drags the resize handle.
+export const DESCRIPTION_HEIGHT_MIN = 80;
+export const DESCRIPTION_HEIGHT_MAX = 600;
+export const DESCRIPTION_HEIGHT_DEFAULT = 300;
+
+// Reset outer margins of the rendered HTML so text starts flush with the padding.
+const DescriptionBody = styled.div`
+	& > :first-child {
+		margin-top: 0;
+	}
+	& > :last-child {
+		margin-bottom: 0;
+	}
+`;
+
+const EMPTY_DESCRIPTION_HTML = '<p style="color: var(--vscode-descriptionForeground); font-style: italic;">No description available</p>';
+
+interface ResizableDescriptionProps {
+	description: string | null | undefined;
+	initialHeight?: number;
+}
+
+const ResizableDescription: FC<ResizableDescriptionProps> = ({ description, initialHeight = DESCRIPTION_HEIGHT_DEFAULT }) => {
+	const [height, setHeight] = useState(initialHeight);
+	const resizeStartRef = useRef({ y: 0, height: 0 });
+
+	const handleResizeStart = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			resizeStartRef.current = { y: e.clientY, height };
+			document.body.style.cursor = 'ns-resize';
+			document.body.style.userSelect = 'none';
+			const onMouseMove = (moveEvent: MouseEvent) => {
+				const delta = moveEvent.clientY - resizeStartRef.current.y;
+				const newHeight = Math.min(DESCRIPTION_HEIGHT_MAX, Math.max(DESCRIPTION_HEIGHT_MIN, resizeStartRef.current.height + delta));
+				setHeight(newHeight);
+			};
+			const onMouseUp = () => {
+				document.removeEventListener('mousemove', onMouseMove);
+				document.removeEventListener('mouseup', onMouseUp);
+				document.body.style.cursor = '';
+				document.body.style.userSelect = '';
+			};
+			document.addEventListener('mousemove', onMouseMove);
+			document.addEventListener('mouseup', onMouseUp);
+		},
+		[height]
+	);
+
+	const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
+			e.preventDefault();
+			const target = e.currentTarget;
+			const selection = window.getSelection();
+			if (selection) {
+				const range = document.createRange();
+				range.selectNodeContents(target);
+				selection.removeAllRanges();
+				selection.addRange(range);
+			}
+		}
+	}, []);
+
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', border: '1px solid var(--vscode-input-border)', borderRadius: '3px', overflow: 'hidden' }}>
+			<DescriptionBody
+				tabIndex={0}
+				// Lenis (smooth scroll) captura els wheel del wrapper; això li diu que ignore aquest scroller.
+				data-lenis-prevent
+				onKeyDown={handleKeyDown}
+				dangerouslySetInnerHTML={{
+					__html: description ? DOMPurify.sanitize(description, { FORBID_ATTR: ['style'] }) : EMPTY_DESCRIPTION_HTML
+				}}
+				style={{
+					width: '100%',
+					minHeight: `${DESCRIPTION_HEIGHT_MIN}px`,
+					maxHeight: `${height}px`,
+					boxSizing: 'border-box',
+					padding: '10px 12px',
+					backgroundColor: 'color-mix(in srgb, var(--vscode-input-background) 60%, var(--vscode-panel-background))',
+					color: 'color-mix(in srgb, var(--vscode-input-foreground) 85%, transparent)',
+					fontSize: '13px',
+					fontFamily: "'Inter', var(--vscode-font-family), -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+					lineHeight: '1.6',
+					overflow: 'auto'
+				}}
+			/>
+			<div
+				role="separator"
+				aria-label="Resize description"
+				onMouseDown={handleResizeStart}
+				style={{
+					height: '8px',
+					backgroundColor: 'var(--vscode-panel-border)',
+					cursor: 'ns-resize',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					flexShrink: 0
+				}}
+			>
+				<div
+					style={{
+						width: '32px',
+						height: '3px',
+						borderRadius: '2px',
+						backgroundColor: 'var(--vscode-descriptionForeground)',
+						opacity: 0.6
+					}}
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default ResizableDescription;

--- a/src/webview/components/common/RevisionDescription.tsx
+++ b/src/webview/components/common/RevisionDescription.tsx
@@ -1,0 +1,191 @@
+import { FC, useMemo } from 'react';
+import DOMPurify from 'dompurify';
+import { parseRevisionDescription, type RevisionChange } from '../../utils/revisionDescription';
+import { createHoverState, getScheduleStateColor, isLightTheme } from '../../utils/themeColors';
+
+interface RevisionDescriptionProps {
+	/** Raw Rally revision `Description`. */
+	description: string;
+}
+
+const STATE_FIELDS = new Set(['SCHEDULE STATE', 'STATE', 'FLOW STATE']);
+const BLOCKED_FIELD = 'BLOCKED';
+
+/**
+ * Accent for a change: green when something was added, red when removed, neutral for edits.
+ * Light theme uses darker variants so the text stays legible on the light editor background,
+ * mirroring how getScheduleStateColor handles the same problem.
+ */
+function changeColor(kind: RevisionChange['kind']): string {
+	const light = isLightTheme();
+	switch (kind) {
+		case 'added':
+			return light ? '#157347' : '#3fc97e';
+		case 'removed':
+			return light ? '#b02a37' : '#f2777a';
+		default:
+			return 'var(--vscode-foreground)';
+	}
+}
+
+/**
+ * Colour dot shown next to a value when the field carries state semantics — Schedule State reuses
+ * the palette the rest of the UI paints states with, Blocked reads red/green.
+ */
+function swatchColor(field: string, value: string | null): string | null {
+	if (value === null) return null;
+	if (STATE_FIELDS.has(field)) return getScheduleStateColor(value);
+	if (field === BLOCKED_FIELD) {
+		const light = isLightTheme();
+		return value.toLowerCase() === 'true' ? (light ? '#b02a37' : '#f2777a') : light ? '#157347' : '#3fc97e';
+	}
+	return null;
+}
+
+const Swatch: FC<{ color: string; dim?: boolean }> = ({ color, dim }) => (
+	<span
+		style={{
+			width: '8px',
+			height: '8px',
+			borderRadius: '2px',
+			backgroundColor: color,
+			opacity: dim ? 0.55 : 1,
+			flexShrink: 0
+		}}
+	/>
+);
+
+/**
+ * Placeholder for a side of the diff that carries no value — either Rally wrote an empty `[]` or
+ * it used the "changed to [X]" form, which it only does when the field had nothing before. Painted
+ * as a dashed outline so "was empty" reads as deliberate instead of looking like a missing value.
+ */
+const EmptyValue: FC = () => (
+	<span
+		style={{
+			display: 'inline-flex',
+			alignItems: 'center',
+			padding: '1px 6px',
+			borderRadius: '4px',
+			fontStyle: 'italic',
+			color: 'var(--vscode-descriptionForeground)',
+			border: `1px dashed ${createHoverState('var(--vscode-foreground)', 0.28)}`,
+			opacity: 0.85,
+			flexShrink: 0
+		}}
+	>
+		empty
+	</span>
+);
+
+const Value: FC<{ field: string; value: string | null; accent: string; dim?: boolean }> = ({ field, value, accent, dim }) => {
+	if (value === null) {
+		return <EmptyValue />;
+	}
+
+	const swatch = swatchColor(field, value);
+	return (
+		<span
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: '5px',
+				padding: '1px 6px',
+				borderRadius: '4px',
+				fontWeight: dim ? 400 : 500,
+				color: dim ? 'var(--vscode-descriptionForeground)' : accent,
+				backgroundColor: createHoverState(dim ? 'var(--vscode-foreground)' : accent, dim ? 0.05 : 0.1),
+				border: `1px solid ${createHoverState(dim ? 'var(--vscode-foreground)' : accent, dim ? 0.12 : 0.22)}`,
+				// Rich-text values arrive as several lines; keep them and cap the height so a long
+				// DESCRIPTION edit scrolls inside its chip instead of burying the rest of the revision.
+				whiteSpace: 'pre-wrap',
+				maxHeight: '180px',
+				overflowY: 'auto',
+				wordBreak: 'break-word',
+				overflowWrap: 'anywhere'
+			}}
+		>
+			{swatch && <Swatch color={swatch} dim={dim} />}
+			{value}
+		</span>
+	);
+};
+
+const ChangeRow: FC<{ change: RevisionChange }> = ({ change }) => {
+	const accent = changeColor(change.kind);
+	// `changed` reads as a transition, added/removed as a single signed value.
+	const marker = change.kind === 'added' ? '+' : change.kind === 'removed' ? '−' : '→';
+
+	return (
+		<div style={{ display: 'flex', alignItems: 'baseline', gap: '8px', flexWrap: 'wrap' }}>
+			<span
+				style={{
+					fontSize: '10.5px',
+					fontWeight: 500,
+					letterSpacing: '0.4px',
+					padding: '2px 7px',
+					borderRadius: '8px',
+					color: 'var(--vscode-descriptionForeground)',
+					backgroundColor: createHoverState('var(--vscode-foreground)', 0.08),
+					border: `1px solid ${createHoverState('var(--vscode-foreground)', 0.12)}`,
+					whiteSpace: 'nowrap',
+					flexShrink: 0
+				}}
+			>
+				{change.field}
+			</span>
+			<span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+				{/* Always render the "before" side of an edit, empty included, so the diff never looks truncated. */}
+				{change.kind === 'changed' && <Value field={change.field} value={change.from} accent={accent} dim />}
+				<span style={{ color: change.kind === 'changed' ? 'var(--vscode-descriptionForeground)' : accent, flexShrink: 0 }}>{marker}</span>
+				<Value field={change.field} value={change.to} accent={accent} />
+			</span>
+		</div>
+	);
+};
+
+/**
+ * Renders a Rally revision description. Most of them follow the "FIELD changed from [x] to [y]"
+ * grammar and get painted as a diff; anything else falls back to the sanitized raw HTML Rally sent,
+ * which is what this view always used to show.
+ */
+const RevisionDescription: FC<RevisionDescriptionProps> = ({ description }) => {
+	const parsed = useMemo(() => parseRevisionDescription(description), [description]);
+
+	if (!parsed.structured) {
+		return (
+			<div
+				style={{
+					padding: '8px',
+					backgroundColor: 'var(--vscode-input-background)',
+					borderRadius: '2px',
+					color: 'var(--vscode-input-foreground)',
+					wordBreak: 'break-word',
+					overflowWrap: 'anywhere'
+				}}
+				dangerouslySetInnerHTML={{
+					__html: DOMPurify.sanitize(description || '', { FORBID_ATTR: ['style'] })
+				}}
+			/>
+		);
+	}
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '6px',
+				padding: '8px',
+				backgroundColor: 'var(--vscode-input-background)',
+				borderRadius: '2px'
+			}}
+		>
+			{parsed.changes.map((change, index) => (
+				<ChangeRow key={`${change.field}-${index}`} change={change} />
+			))}
+		</div>
+	);
+};
+
+export default RevisionDescription;

--- a/src/webview/components/common/RevisionDescription.tsx
+++ b/src/webview/components/common/RevisionDescription.tsx
@@ -78,7 +78,7 @@ const EmptyValue: FC = () => (
 	</span>
 );
 
-const Value: FC<{ field: string; value: string | null; accent: string; dim?: boolean }> = ({ field, value, accent, dim }) => {
+const Value: FC<{ field: string; value: string | null; accent: string; dim?: boolean; struck?: boolean }> = ({ field, value, accent, dim, struck }) => {
 	if (value === null) {
 		return <EmptyValue />;
 	}
@@ -106,7 +106,8 @@ const Value: FC<{ field: string; value: string | null; accent: string; dim?: boo
 			}}
 		>
 			{swatch && <Swatch color={swatch} dim={dim} />}
-			{value}
+			{/* Struck through on the span holding the text, not the chip, so the swatch stays untouched. */}
+			<span style={struck ? { textDecoration: 'line-through' } : undefined}>{value}</span>
 		</span>
 	);
 };
@@ -138,7 +139,7 @@ const ChangeRow: FC<{ change: RevisionChange }> = ({ change }) => {
 				{/* Always render the "before" side of an edit, empty included, so the diff never looks truncated. */}
 				{change.kind === 'changed' && <Value field={change.field} value={change.from} accent={accent} dim />}
 				<span style={{ color: change.kind === 'changed' ? 'var(--vscode-descriptionForeground)' : accent, flexShrink: 0 }}>{marker}</span>
-				<Value field={change.field} value={change.to} accent={accent} />
+				<Value field={change.field} value={change.to} accent={accent} struck={change.kind === 'removed'} />
 			</span>
 		</div>
 	);

--- a/src/webview/components/common/ScreenHeader.tsx
+++ b/src/webview/components/common/ScreenHeader.tsx
@@ -1,4 +1,6 @@
 import type React from 'react';
+import EntityTypeBadge from './EntityTypeBadge';
+import type { RallyEntityType } from '../../../types/rally';
 
 interface ScreenHeaderProps {
 	title: string;
@@ -7,9 +9,11 @@ interface ScreenHeaderProps {
 	sticky?: boolean;
 	rightContent?: React.ReactNode;
 	titleActions?: React.ReactNode;
+	/** Detail screens pass the record type so it shows as a badge instead of a text prefix in the title. */
+	entityType?: RallyEntityType;
 }
 
-const ScreenHeader: React.FC<ScreenHeaderProps> = ({ title, onBack, showBackButton = false, sticky = false, rightContent, titleActions }) => {
+const ScreenHeader: React.FC<ScreenHeaderProps> = ({ title, onBack, showBackButton = false, sticky = false, rightContent, titleActions, entityType }) => {
 	const stickyHeader = Boolean(sticky || (showBackButton && onBack));
 	return (
 		<div
@@ -35,7 +39,7 @@ const ScreenHeader: React.FC<ScreenHeaderProps> = ({ title, onBack, showBackButt
 					: {})
 			}}
 		>
-			<div style={{ display: 'flex', alignItems: 'center' }}>
+			<div style={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
 				{showBackButton && onBack && (
 					<button
 						type="button"
@@ -66,7 +70,8 @@ const ScreenHeader: React.FC<ScreenHeaderProps> = ({ title, onBack, showBackButt
 						</svg>
 					</button>
 				)}
-				<span>
+				{entityType && <EntityTypeBadge type={entityType} display="icon" />}
+				<span style={{ marginLeft: entityType ? '8px' : 0 }}>
 					{title}
 					{titleActions}
 				</span>

--- a/src/webview/components/common/UserStoriesTable.tsx
+++ b/src/webview/components/common/UserStoriesTable.tsx
@@ -214,11 +214,12 @@ const UserStoriesTable: React.FC<UserStoriesTableProps> = ({ userStories, loadin
 		defectsCount: number;
 		discussionCount: number;
 		blocked?: boolean;
-	}> = ({ tasksCount, testCasesCount, defectsCount, discussionCount, blocked }) => {
+		blockedReason?: string | null;
+	}> = ({ tasksCount, testCasesCount, defectsCount, discussionCount, blocked, blockedReason }) => {
 		return (
 			<div style={{ display: 'flex', gap: '8px', alignItems: 'center', color: themeColors.foreground }}>
 				{blocked && (
-					<span title="Blocked" style={{ display: 'inline-flex', alignItems: 'center', color: 'color(srgb 0.82 0.32 0.32 / 1)' }}>
+					<span title={blockedReason ? `Blocked: ${blockedReason}` : 'Blocked'} style={{ display: 'inline-flex', alignItems: 'center', color: 'color(srgb 0.82 0.32 0.32 / 1)' }}>
 						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" style={{ width: '14px', height: '14px' }}>
 							<path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636" />
 						</svg>
@@ -345,7 +346,7 @@ const UserStoriesTable: React.FC<UserStoriesTableProps> = ({ userStories, loadin
 								<td style={{ padding: '10px 12px', fontWeight: '300', color: getScheduleStateColor(userStory.scheduleState || 'new'), overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>{userStory.scheduleState || 'N/A'}</td>
 								<td style={{ padding: '10px 12px', fontWeight: '300', textAlign: 'center', overflow: 'hidden', whiteSpace: 'nowrap' }}>{userStory.taskEstimateTotal !== undefined && userStory.taskEstimateTotal !== null ? `${userStory.taskEstimateTotal}h` : '0h'}</td>
 								<td style={{ padding: '10px 12px', fontWeight: '300', textAlign: 'center', overflow: 'hidden' }}>
-									<RelatedItemsIcons tasksCount={userStory.tasksCount} testCasesCount={userStory.testCasesCount} defectsCount={userStory.defectsCount} discussionCount={userStory.discussionCount} blocked={userStory.blocked} />
+									<RelatedItemsIcons tasksCount={userStory.tasksCount} testCasesCount={userStory.testCasesCount} defectsCount={userStory.defectsCount} discussionCount={userStory.discussionCount} blocked={userStory.blocked} blockedReason={userStory.blockedReason} />
 								</td>
 							</tr>
 						))}

--- a/src/webview/components/common/UserStoryForm.tsx
+++ b/src/webview/components/common/UserStoryForm.tsx
@@ -6,6 +6,7 @@ import { type UserStory } from '../../../types/rally';
 import { isLightTheme, getScheduleStateColor as getThemeScheduleStateColor } from '../../utils/themeColors';
 import { getVsCodeApi } from '../../utils/vscodeApi';
 import RevisionTimeline from './RevisionTimeline';
+import ResizableDescription from './ResizableDescription';
 import './CollapsibleCard';
 
 const StatusPill = styled.div<{ isBlocked: boolean }>`
@@ -21,16 +22,6 @@ const StatusPill = styled.div<{ isBlocked: boolean }>`
 	background: ${props => (props.isBlocked ? 'color(srgb 0.75 0.2 0.2 / 0.15)' : 'color(srgb 0.15 0.55 0.3 / 0.15)')};
 	color: ${props => (props.isBlocked ? 'color(srgb 0.82 0.32 0.32 / 1)' : 'color(srgb 0.28 0.72 0.46 / 1)')};
 	border: 1px solid ${props => (props.isBlocked ? 'color(srgb 0.75 0.2 0.2 / 0.35)' : 'color(srgb 0.15 0.55 0.3 / 0.35)')};
-`;
-
-// Reset outer margins of the rendered HTML so text starts flush with the padding.
-const DescriptionBody = styled.div`
-	& > :first-child {
-		margin-top: 0;
-	}
-	& > :last-child {
-		margin-bottom: 0;
-	}
 `;
 
 // StatPill component with theme-aware styling
@@ -148,20 +139,14 @@ const RevisionsIcon = ({ size = '18px' }: { size?: string }) => (
 	</svg>
 );
 
-const DESCRIPTION_HEIGHT_MIN = 80;
-const DESCRIPTION_HEIGHT_MAX = 600;
-const DESCRIPTION_HEIGHT_DEFAULT = 300;
-
 const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTab = 'tasks', onAdditionalTabChange, additionalTabContent, collaborationEnabled = false, iterations }) => {
 	const vscode = useMemo(() => getVsCodeApi(), []);
 	const [requestSupportLoading, setRequestSupportLoading] = useState(false);
 	const [requestSupportSuccess, setRequestSupportSuccess] = useState(false);
-	const [descriptionHeight, setDescriptionHeight] = useState(DESCRIPTION_HEIGHT_DEFAULT);
 	const [revisions, setRevisions] = useState<any[]>([]);
 	const [revisionsCount, setRevisionsCount] = useState<number | null>(null);
 	const [revisionsLoading, setRevisionsLoading] = useState(false);
 	const [revisionsLoaded, setRevisionsLoaded] = useState(false);
-	const resizeStartRef = useRef({ y: 0, height: 0 });
 	const timelineCardRef = useRef<HTMLElement | null>(null);
 	const timelineExpandedRef = useRef(false);
 
@@ -271,43 +256,6 @@ const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTa
 		card.addEventListener('toggle', handleToggle);
 		return () => card.removeEventListener('toggle', handleToggle);
 	}, [revisionsLoaded, revisionsLoading, loadRevisions]);
-
-	const handleDescriptionResizeStart = useCallback(
-		(e: React.MouseEvent) => {
-			e.preventDefault();
-			resizeStartRef.current = { y: e.clientY, height: descriptionHeight };
-			document.body.style.cursor = 'ns-resize';
-			document.body.style.userSelect = 'none';
-			const onMouseMove = (moveEvent: MouseEvent) => {
-				const delta = moveEvent.clientY - resizeStartRef.current.y;
-				const newHeight = Math.min(DESCRIPTION_HEIGHT_MAX, Math.max(DESCRIPTION_HEIGHT_MIN, resizeStartRef.current.height + delta));
-				setDescriptionHeight(newHeight);
-			};
-			const onMouseUp = () => {
-				document.removeEventListener('mousemove', onMouseMove);
-				document.removeEventListener('mouseup', onMouseUp);
-				document.body.style.cursor = '';
-				document.body.style.userSelect = '';
-			};
-			document.addEventListener('mousemove', onMouseMove);
-			document.addEventListener('mouseup', onMouseUp);
-		},
-		[descriptionHeight]
-	);
-
-	const handleDescriptionKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
-			e.preventDefault();
-			const target = e.currentTarget;
-			const selection = window.getSelection();
-			if (selection) {
-				const range = document.createRange();
-				range.selectNodeContents(target);
-				selection.removeAllRanges();
-				selection.addRange(range);
-			}
-		}
-	}, []);
 
 	const handleRequestSupport = useCallback(() => {
 		if (!vscode) return;
@@ -477,54 +425,7 @@ const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTa
 					<div style={{ display: 'flex', flexDirection: 'column', gap: '10px', gridColumn: '1 / -1' }}>
 						<h3 style={{ margin: '18px 0 3px 0', color: 'var(--vscode-foreground)', fontSize: '14px' }}>Description</h3>
 
-						<div style={{ display: 'flex', flexDirection: 'column', border: '1px solid var(--vscode-input-border)', borderRadius: '3px', overflow: 'hidden' }}>
-							<DescriptionBody
-								tabIndex={0}
-								// Lenis (smooth scroll) captura els wheel del wrapper; això li diu que ignore aquest scroller.
-								data-lenis-prevent
-								onKeyDown={handleDescriptionKeyDown}
-								dangerouslySetInnerHTML={{
-									__html: userStory.description ? DOMPurify.sanitize(userStory.description, { FORBID_ATTR: ['style'] }) : '<p style="color: var(--vscode-descriptionForeground); font-style: italic;">No description available</p>'
-								}}
-								style={{
-									width: '100%',
-									minHeight: `${DESCRIPTION_HEIGHT_MIN}px`,
-									maxHeight: `${descriptionHeight}px`,
-									boxSizing: 'border-box',
-									padding: '10px 12px',
-									backgroundColor: 'color-mix(in srgb, var(--vscode-input-background) 60%, var(--vscode-panel-background))',
-									color: 'color-mix(in srgb, var(--vscode-input-foreground) 85%, transparent)',
-									fontSize: '13px',
-									fontFamily: "'Inter', var(--vscode-font-family), -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-									lineHeight: '1.6',
-									overflow: 'auto'
-								}}
-							/>
-							<div
-								role="separator"
-								aria-label="Resize description"
-								onMouseDown={handleDescriptionResizeStart}
-								style={{
-									height: '8px',
-									backgroundColor: 'var(--vscode-panel-border)',
-									cursor: 'ns-resize',
-									display: 'flex',
-									alignItems: 'center',
-									justifyContent: 'center',
-									flexShrink: 0
-								}}
-							>
-								<div
-									style={{
-										width: '32px',
-										height: '3px',
-										borderRadius: '2px',
-										backgroundColor: 'var(--vscode-descriptionForeground)',
-										opacity: 0.6
-									}}
-								/>
-							</div>
-						</div>
+						<ResizableDescription description={userStory.description} />
 					</div>
 				</div>
 			</collapsible-card>

--- a/src/webview/components/common/UserStoryForm.tsx
+++ b/src/webview/components/common/UserStoryForm.tsx
@@ -480,6 +480,8 @@ const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTa
 						<div style={{ display: 'flex', flexDirection: 'column', border: '1px solid var(--vscode-input-border)', borderRadius: '3px', overflow: 'hidden' }}>
 							<DescriptionBody
 								tabIndex={0}
+								// Lenis (smooth scroll) captura els wheel del wrapper; això li diu que ignore aquest scroller.
+								data-lenis-prevent
 								onKeyDown={handleDescriptionKeyDown}
 								dangerouslySetInnerHTML={{
 									__html: userStory.description ? DOMPurify.sanitize(userStory.description, { FORBID_ATTR: ['style'] }) : '<p style="color: var(--vscode-descriptionForeground); font-style: italic;">No description available</p>'

--- a/src/webview/components/common/UserStoryForm.tsx
+++ b/src/webview/components/common/UserStoryForm.tsx
@@ -1,10 +1,11 @@
 import { FC, useState, useCallback, useMemo, useRef, useEffect, type ReactNode } from 'react';
 import styled from 'styled-components';
-import DOMPurify from 'dompurify';
 import { AvatarFormField } from './Avatar';
-import { type UserStory } from '../../../types/rally';
+import { type Revision, type UserStory } from '../../../types/rally';
 import { isLightTheme, getScheduleStateColor as getThemeScheduleStateColor } from '../../utils/themeColors';
 import { getVsCodeApi } from '../../utils/vscodeApi';
+import BlockedReasonBanner from './BlockedReasonBanner';
+import RevisionDescription from './RevisionDescription';
 import RevisionTimeline from './RevisionTimeline';
 import ResizableDescription from './ResizableDescription';
 import './CollapsibleCard';
@@ -143,7 +144,7 @@ const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTa
 	const vscode = useMemo(() => getVsCodeApi(), []);
 	const [requestSupportLoading, setRequestSupportLoading] = useState(false);
 	const [requestSupportSuccess, setRequestSupportSuccess] = useState(false);
-	const [revisions, setRevisions] = useState<any[]>([]);
+	const [revisions, setRevisions] = useState<Revision[]>([]);
 	const [revisionsCount, setRevisionsCount] = useState<number | null>(null);
 	const [revisionsLoading, setRevisionsLoading] = useState(false);
 	const [revisionsLoaded, setRevisionsLoaded] = useState(false);
@@ -343,8 +344,16 @@ const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTa
 							{userStory.scheduleState}
 						</div>
 					)}
-					<StatusPill isBlocked={userStory.blocked}>{userStory.blocked ? 'Blocked' : 'Not Blocked'}</StatusPill>
+					<StatusPill isBlocked={userStory.blocked} title={userStory.blocked ? (userStory.blockedReason ?? undefined) : undefined}>
+						{userStory.blocked ? 'Blocked' : 'Not Blocked'}
+					</StatusPill>
 				</div>
+
+				{userStory.blocked && userStory.blockedReason && (
+					<div style={{ marginBottom: '16px' }}>
+						<BlockedReasonBanner blocked={userStory.blocked} blockedReason={userStory.blockedReason} />
+					</div>
+				)}
 
 				<div style={{ marginBottom: '16px' }}>
 					<label style={{ display: 'block', marginBottom: '4px', fontSize: '12px', color: 'var(--vscode-descriptionForeground)' }}>Name</label>
@@ -481,9 +490,9 @@ const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTa
 											Showing latest {revisions.length} of {revisionsCount} revisions
 										</div>
 									)}
-									{revisions.map((revision, index) => (
+									{revisions.map(revision => (
 										<div
-											key={index}
+											key={revision.revisionNumber}
 											style={{
 												padding: '12px',
 												backgroundColor: 'color-mix(in srgb, var(--vscode-input-background) 60%, var(--vscode-panel-background))',
@@ -499,19 +508,7 @@ const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTa
 											<div style={{ marginBottom: '6px', color: 'var(--vscode-descriptionForeground)' }}>
 												By: <strong>{revision.author}</strong>
 											</div>
-											<div
-												style={{
-													padding: '8px',
-													backgroundColor: 'var(--vscode-input-background)',
-													borderRadius: '2px',
-													color: 'var(--vscode-input-foreground)',
-													wordBreak: 'break-word',
-													overflowWrap: 'anywhere'
-												}}
-												dangerouslySetInnerHTML={{
-													__html: DOMPurify.sanitize(revision.description || '', { FORBID_ATTR: ['style'] })
-												}}
-											/>
+											<RevisionDescription description={revision.description || ''} />
 										</div>
 									))}
 								</div>

--- a/src/webview/components/common/UserStoryForm.tsx
+++ b/src/webview/components/common/UserStoryForm.tsx
@@ -1,6 +1,7 @@
 import { FC, useState, useCallback, useMemo, useRef, useEffect, type ReactNode } from 'react';
 import styled from 'styled-components';
 import { AvatarFormField } from './Avatar';
+import { EntityRefFormField } from './EntityTypeBadge';
 import { type Revision, type UserStory } from '../../../types/rally';
 import { isLightTheme, getScheduleStateColor as getThemeScheduleStateColor } from '../../utils/themeColors';
 import { getVsCodeApi } from '../../utils/vscodeApi';
@@ -408,21 +409,7 @@ const UserStoryForm: FC<UserStoryFormProps> = ({ userStory, selectedAdditionalTa
 
 					<div>
 						<label style={{ display: 'block', marginBottom: '4px', fontSize: '12px', color: 'var(--vscode-descriptionForeground)' }}>Sprint</label>
-						<input
-							type="text"
-							value={typeof userStory.iteration === 'string' ? userStory.iteration : userStory.iteration?._refObjectName || 'N/A'}
-							readOnly
-							style={{
-								width: '100%',
-								boxSizing: 'border-box',
-								padding: '6px 8px',
-								backgroundColor: 'var(--vscode-input-background)',
-								color: 'var(--vscode-input-foreground)',
-								border: '1px solid var(--vscode-input-border)',
-								borderRadius: '3px',
-								fontSize: '13px'
-							}}
-						/>
+						<EntityRefFormField type="sprint" value={typeof userStory.iteration === 'string' ? userStory.iteration : userStory.iteration?._refObjectName} emptyLabel="N/A" />
 					</div>
 
 					<div>

--- a/src/webview/components/common/icons/EntityTypeIcons.tsx
+++ b/src/webview/components/common/icons/EntityTypeIcons.tsx
@@ -1,7 +1,12 @@
 // Small outline icons for Rally entity types, shared across global search results and the
 // Recently Viewed list so both surfaces use the exact same iconography.
-export const UserStoryTypeIcon = () => (
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: '14px', height: '14px', flexShrink: 0 }}>
+
+export interface EntityTypeIconProps {
+	/** Costat de la icona en píxels. Per defecte 14px, la mida dels badges de tipus. */
+	size?: number;
+}
+export const UserStoryTypeIcon = ({ size = 14 }: EntityTypeIconProps) => (
+	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: `${size}px`, height: `${size}px`, flexShrink: 0 }}>
 		<path
 			strokeLinecap="round"
 			strokeLinejoin="round"
@@ -10,8 +15,8 @@ export const UserStoryTypeIcon = () => (
 	</svg>
 );
 
-export const TaskTypeIcon = () => (
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: '14px', height: '14px', flexShrink: 0 }}>
+export const TaskTypeIcon = ({ size = 14 }: EntityTypeIconProps) => (
+	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: `${size}px`, height: `${size}px`, flexShrink: 0 }}>
 		<path
 			strokeLinecap="round"
 			strokeLinejoin="round"
@@ -21,14 +26,14 @@ export const TaskTypeIcon = () => (
 	</svg>
 );
 
-export const TestCaseTypeIcon = () => (
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: '14px', height: '14px', flexShrink: 0 }}>
+export const TestCaseTypeIcon = ({ size = 14 }: EntityTypeIconProps) => (
+	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: `${size}px`, height: `${size}px`, flexShrink: 0 }}>
 		<path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
 	</svg>
 );
 
-export const DefectTypeIcon = () => (
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: '14px', height: '14px', flexShrink: 0 }}>
+export const DefectTypeIcon = ({ size = 14 }: EntityTypeIconProps) => (
+	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: `${size}px`, height: `${size}px`, flexShrink: 0 }}>
 		<path
 			strokeLinecap="round"
 			strokeLinejoin="round"
@@ -37,8 +42,8 @@ export const DefectTypeIcon = () => (
 	</svg>
 );
 
-export const SprintTypeIcon = () => (
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: '14px', height: '14px', flexShrink: 0 }}>
+export const SprintTypeIcon = ({ size = 14 }: EntityTypeIconProps) => (
+	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: `${size}px`, height: `${size}px`, flexShrink: 0 }}>
 		<path
 			strokeLinecap="round"
 			strokeLinejoin="round"

--- a/src/webview/components/sections/portfolio/AllDefectsView.tsx
+++ b/src/webview/components/sections/portfolio/AllDefectsView.tsx
@@ -32,7 +32,8 @@ const AllDefectsView: FC<PortfolioViewProps> = ({ defects, defectsLoading, defec
 			{currentScreen === 'defectDetail' && selectedDefect && (
 				<>
 					<ScreenHeader
-						title={`Defect "${selectedDefect.formattedId}: ${selectedDefect.name}"`}
+						entityType="defect"
+						title={`${selectedDefect.formattedId}: ${selectedDefect.name}`}
 						showBackButton={true}
 						onBack={onBackToDefects}
 						titleActions={

--- a/src/webview/components/sections/portfolio/AllUserStoriesView.tsx
+++ b/src/webview/components/sections/portfolio/AllUserStoriesView.tsx
@@ -89,7 +89,8 @@ const AllUserStoriesView: FC<PortfolioViewProps> = ({
 			{currentScreen === 'userStoryDetail' && selectedUserStory && (
 				<>
 					<ScreenHeader
-						title={`User story "${selectedUserStory.formattedId}: ${selectedUserStory.name}"`}
+						entityType="userstory"
+						title={`${selectedUserStory.formattedId}: ${selectedUserStory.name}`}
 						showBackButton={true}
 						onBack={onBackToUserStories}
 						titleActions={

--- a/src/webview/components/sections/portfolio/BySprintsView.tsx
+++ b/src/webview/components/sections/portfolio/BySprintsView.tsx
@@ -131,7 +131,8 @@ const BySprintsView: FC<PortfolioViewProps> = ({
 			{currentScreen === 'userStories' && selectedIteration && (
 				<>
 					<ScreenHeader
-						title={`Sprint "${selectedIteration.name}"`}
+						entityType="sprint"
+						title={selectedIteration.name}
 						showBackButton={true}
 						onBack={onBackToIterations}
 						titleActions={
@@ -170,7 +171,8 @@ const BySprintsView: FC<PortfolioViewProps> = ({
 			{currentScreen === 'userStoryDetail' && selectedUserStory && (
 				<>
 					<ScreenHeader
-						title={`User story "${selectedUserStory.formattedId}: ${selectedUserStory.name}"`}
+						entityType="userstory"
+						title={`${selectedUserStory.formattedId}: ${selectedUserStory.name}`}
 						showBackButton={true}
 						onBack={onBackToUserStories}
 						titleActions={

--- a/src/webview/hooks/useNavigationHistory.ts
+++ b/src/webview/hooks/useNavigationHistory.ts
@@ -55,6 +55,13 @@ export function useNavigationHistory() {
 		[syncFlags]
 	);
 
+	// Consulta l'entrada anterior sense moure l'índex, per decidir si una fletxa
+	// de retrocés pot delegar a `goBack` en comptes de reconstruir l'estat a mà.
+	const peekBack = useCallback((): NavKey | null => {
+		if (indexRef.current <= 0) return null;
+		return entriesRef.current[indexRef.current - 1];
+	}, []);
+
 	const goBack = useCallback((): NavKey | null => {
 		if (indexRef.current <= 0) return null;
 		indexRef.current -= 1;
@@ -69,5 +76,5 @@ export function useNavigationHistory() {
 		return entriesRef.current[indexRef.current];
 	}, [syncFlags]);
 
-	return { pushEntry, goBack, goForward, canGoBack, canGoForward };
+	return { pushEntry, peekBack, goBack, goForward, canGoBack, canGoForward };
 }

--- a/src/webview/hooks/useNavigationHistory.ts
+++ b/src/webview/hooks/useNavigationHistory.ts
@@ -55,6 +55,25 @@ export function useNavigationHistory() {
 		[syncFlags]
 	);
 
+	// Substitueix l'entrada actual en comptes d'apilar-ne una de nova. Ho fa servir la
+	// fletxa enrere quan no hi ha entrada anterior a la qual tornar: apilar-ne una
+	// deixaria el detall que acabem de tancar a la branca "endavant".
+	const replaceEntry = useCallback(
+		(key: NavKey) => {
+			if (indexRef.current < 0) {
+				entriesRef.current = [key];
+				indexRef.current = 0;
+			} else {
+				// Igual que un push, invalida la branca cap endavant.
+				const truncated = entriesRef.current.slice(0, indexRef.current + 1);
+				truncated[indexRef.current] = key;
+				entriesRef.current = truncated;
+			}
+			syncFlags();
+		},
+		[syncFlags]
+	);
+
 	// Consulta l'entrada anterior sense moure l'índex, per decidir si una fletxa
 	// de retrocés pot delegar a `goBack` en comptes de reconstruir l'estat a mà.
 	const peekBack = useCallback((): NavKey | null => {
@@ -76,5 +95,5 @@ export function useNavigationHistory() {
 		return entriesRef.current[indexRef.current];
 	}, [syncFlags]);
 
-	return { pushEntry, peekBack, goBack, goForward, canGoBack, canGoForward };
+	return { pushEntry, replaceEntry, peekBack, goBack, goForward, canGoBack, canGoForward };
 }

--- a/src/webview/utils/revisionDescription.test.ts
+++ b/src/webview/utils/revisionDescription.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { htmlToPlainText, parseRevisionDescription } from './revisionDescription';
+
+describe('parseRevisionDescription', () => {
+	it('parses a simple from/to change', () => {
+		const result = parseRevisionDescription('ITERATION changed from [Sprint 91] to [Sprint 92]');
+		expect(result.structured).toBe(true);
+		expect(result.changes).toEqual([{ field: 'ITERATION', kind: 'changed', from: 'Sprint 91', to: 'Sprint 92' }]);
+	});
+
+	it('parses multi-word field names', () => {
+		const result = parseRevisionDescription('TASK ESTIMATE TOTAL changed from [118.0] to [88.0]');
+		expect(result.structured).toBe(true);
+		expect(result.changes[0]).toEqual({ field: 'TASK ESTIMATE TOTAL', kind: 'changed', from: '118.0', to: '88.0' });
+	});
+
+	it('parses several changes in one description', () => {
+		const result = parseRevisionDescription('RELEASE added [2026-Q3], MILESTONES added [MI43737: (2026-09-22) IOP Salesforce]');
+		expect(result.structured).toBe(true);
+		expect(result.changes).toEqual([
+			{ field: 'RELEASE', kind: 'added', from: null, to: '2026-Q3' },
+			{ field: 'MILESTONES', kind: 'added', from: null, to: 'MI43737: (2026-09-22) IOP Salesforce' }
+		]);
+	});
+
+	it('keeps commas that live inside a bracketed value', () => {
+		const result = parseRevisionDescription('MILESTONES added [MI1: Salesforce, Billing, Core]');
+		expect(result.structured).toBe(true);
+		expect(result.changes).toHaveLength(1);
+		expect(result.changes[0].to).toBe('MI1: Salesforce, Billing, Core');
+	});
+
+	it('keeps brackets nested inside a value', () => {
+		const result = parseRevisionDescription('TAGS added [[US Quality] 28/100 - KO]');
+		expect(result.structured).toBe(true);
+		expect(result.changes[0]).toEqual({ field: 'TAGS', kind: 'added', from: null, to: '[US Quality] 28/100 - KO' });
+	});
+
+	it('keeps nested brackets when another clause follows', () => {
+		const result = parseRevisionDescription('TASK STATUS changed from [NONE] to [DEFINED], TASKS added [TA1110817: [AGENTQA] Evaluation 28/100]');
+		expect(result.structured).toBe(true);
+		expect(result.changes).toEqual([
+			{ field: 'TASK STATUS', kind: 'changed', from: 'NONE', to: 'DEFINED' },
+			{ field: 'TASKS', kind: 'added', from: null, to: 'TA1110817: [AGENTQA] Evaluation 28/100' }
+		]);
+	});
+
+	it('reports no previous value for "changed to"', () => {
+		const result = parseRevisionDescription('BLOCKED REASON changed to [waiting for API]');
+		expect(result.structured).toBe(true);
+		expect(result.changes[0]).toEqual({ field: 'BLOCKED REASON', kind: 'changed', from: null, to: 'waiting for API' });
+	});
+
+	it('parses removals', () => {
+		const result = parseRevisionDescription('MILESTONES removed [MI43737: IOP Salesforce]');
+		expect(result.structured).toBe(true);
+		expect(result.changes[0]).toMatchObject({ kind: 'removed', to: 'MI43737: IOP Salesforce' });
+	});
+
+	it('mixes verbs within one description', () => {
+		const result = parseRevisionDescription('BLOCKED changed from [false] to [true], BLOCKED REASON changed to [waiting], TAGS removed [urgent]');
+		expect(result.structured).toBe(true);
+		expect(result.changes.map(change => change.kind)).toEqual(['changed', 'changed', 'removed']);
+		expect(result.changes.map(change => change.field)).toEqual(['BLOCKED', 'BLOCKED REASON', 'TAGS']);
+	});
+
+	it('turns empty brackets into null', () => {
+		const result = parseRevisionDescription('OWNER changed from [] to [Ada Lovelace]');
+		expect(result.structured).toBe(true);
+		expect(result.changes[0]).toMatchObject({ from: null, to: 'Ada Lovelace' });
+	});
+
+	it('decodes HTML entities in values', () => {
+		const result = parseRevisionDescription('NAME changed from [A &amp; B] to [C &amp; D]');
+		expect(result.structured).toBe(true);
+		expect(result.changes[0]).toMatchObject({ from: 'A & B', to: 'C & D' });
+	});
+
+	it('collapses newlines and repeated whitespace', () => {
+		const result = parseRevisionDescription('ITERATION changed from [Sprint 91]\n   to [Sprint 92]');
+		expect(result.structured).toBe(true);
+		expect(result.changes).toHaveLength(1);
+	});
+
+	it('strips markup from rich-text values', () => {
+		const result = parseRevisionDescription('DESCRIPTION changed from [<p>Old text.</p>] to [<p>New text:</p><ol><li>First</li><li>Second</li></ol>]');
+		expect(result.structured).toBe(true);
+		expect(result.changes[0].from).toBe('Old text.');
+		expect(result.changes[0].to).toBe('New text:\n• First\n• Second');
+	});
+
+	it('treats a value that is only markup as empty', () => {
+		const result = parseRevisionDescription('NOTES changed from [<p>&nbsp;</p>] to [Something]');
+		expect(result.structured).toBe(true);
+		expect(result.changes[0].from).toBeNull();
+	});
+
+	it('rejects free text', () => {
+		expect(parseRevisionDescription('Original story creation').structured).toBe(false);
+	});
+
+	it('rejects descriptions carrying raw HTML', () => {
+		const result = parseRevisionDescription('DESCRIPTION changed from [<p>old</p>] to [<p>new</p>]<br>and more');
+		expect(result.structured).toBe(false);
+		expect(result.changes).toEqual([]);
+	});
+
+	it('never parses partially — a trailing free-text tail invalidates the whole description', () => {
+		const result = parseRevisionDescription('ITERATION changed from [Sprint 91] to [Sprint 92] plus some manual note');
+		expect(result.structured).toBe(false);
+		expect(result.changes).toEqual([]);
+	});
+
+	it('does not mistake lower-case prose for a field name', () => {
+		expect(parseRevisionDescription('the field ITERATION changed from [a] to [b]').structured).toBe(false);
+	});
+
+	it('handles empty and missing input', () => {
+		expect(parseRevisionDescription('')).toEqual({ changes: [], structured: false });
+		expect(parseRevisionDescription('   ')).toEqual({ changes: [], structured: false });
+		expect(parseRevisionDescription(null)).toEqual({ changes: [], structured: false });
+		expect(parseRevisionDescription(undefined)).toEqual({ changes: [], structured: false });
+	});
+
+	it('is reusable across calls (global regex state is reset)', () => {
+		const text = 'ITERATION changed from [Sprint 91] to [Sprint 92]';
+		expect(parseRevisionDescription(text).changes).toEqual(parseRevisionDescription(text).changes);
+	});
+});
+
+describe('htmlToPlainText', () => {
+	it('leaves plain values untouched', () => {
+		expect(htmlToPlainText('Sprint 92')).toBe('Sprint 92');
+	});
+
+	it('keeps paragraph boundaries as line breaks instead of gluing words together', () => {
+		expect(htmlToPlainText('<p>Uno</p><p>Dos</p>')).toBe('Uno\nDos');
+	});
+
+	it('bullets list items', () => {
+		expect(htmlToPlainText('<ul><li>Uno</li><li>Dos</li></ul>')).toBe('• Uno\n• Dos');
+	});
+
+	it('flattens nested lists', () => {
+		expect(htmlToPlainText('<ol><li>Uno<ol><li>Uno.a</li></ol></li></ol>')).toBe('• Uno\n• Uno.a');
+	});
+
+	it('turns <br> into a line break', () => {
+		expect(htmlToPlainText('Uno<br/>Dos')).toBe('Uno\nDos');
+	});
+
+	it('drops attributes and inline tags', () => {
+		expect(htmlToPlainText('<p class="x">Un <strong>valor</strong> destacat</p>')).toBe('Un valor destacat');
+	});
+
+	it('collapses markup-only input to an empty string', () => {
+		expect(htmlToPlainText('<p></p><ol></ol>')).toBe('');
+	});
+});

--- a/src/webview/utils/revisionDescription.ts
+++ b/src/webview/utils/revisionDescription.ts
@@ -1,0 +1,151 @@
+/**
+ * Utilities to turn a Rally revision `Description` into structured field changes.
+ *
+ * Rally stores every change as free text, and the vast majority follows a very regular grammar:
+ *   "ITERATION changed from [Sprint 91] to [Sprint 92]"
+ *   "BLOCKED REASON changed to [waiting for API]"
+ *   "RELEASE added [2026-Q3], MILESTONES added [MI43737: (2026-09-22) IOP Salesforce]"
+ *
+ * Parsing it lets the detail view paint a diff instead of a sentence. Some revisions do NOT
+ * follow it though (DESCRIPTION changes carry raw HTML, "Original story creation", free text),
+ * so the parser is deliberately all-or-nothing: unless the whole string is accounted for it
+ * reports `structured: false` and the caller falls back to rendering the sanitized HTML.
+ */
+
+export type RevisionChangeKind = 'changed' | 'added' | 'removed';
+
+export interface RevisionChange {
+	/** Rally field name as written in the description, e.g. 'ITERATION', 'TASK ESTIMATE TOTAL'. */
+	field: string;
+	kind: RevisionChangeKind;
+	/** Previous value; null for `changed to [X]`, `added` and `removed`. */
+	from: string | null;
+	/** New value, or the added/removed value. Null when Rally wrote an empty `[]`. */
+	to: string | null;
+}
+
+export interface ParsedRevisionDescription {
+	changes: RevisionChange[];
+	/** False → the text does not fit the grammar; the caller must fall back to the HTML render. */
+	structured: boolean;
+}
+
+// Case-sensitive on purpose: Rally writes field names in upper case and verbs in lower case, so
+// requiring that shape keeps free-text prose from being mistaken for a field name. Anything that
+// doesn't match simply falls back to the HTML render, so being strict here is the safe direction.
+const FIELD = '[A-Z][A-Z0-9 _/&.-]*?';
+const VERB = '(?:changed from|changed to|added|removed)';
+
+// Rally does not escape brackets, so a value can contain them — "TAGS added [[US Quality] 28/100]"
+// or "TASKS added [TA1110817: [AGENTQA] Evaluation]". A value therefore runs lazily up to the last
+// `]` that is followed by either the end of the text or the next `FIELD verb` clause, rather than
+// stopping at the first one. The same lookahead is why commas inside a value are safe: a comma only
+// ends a value when a real clause follows it.
+const VALUE = '\\[(.*?)\\]';
+const VALUE_END = `(?=\\s*$|,\\s*${FIELD}\\s+${VERB}\\s)`;
+
+// Anchored to the start of the text or to a `, ` separator so field names can't be picked up from
+// inside a value.
+const CHANGE_RE = new RegExp(`(?:^|,\\s*)(${FIELD})\\s+(?:` + `changed from ${VALUE}(?=\\s+to\\s+\\[)\\s+to\\s+${VALUE}${VALUE_END}` + `|changed to ${VALUE}${VALUE_END}` + `|(added|removed) ${VALUE}${VALUE_END}` + ')', 'g');
+
+const ENTITIES: Record<string, string> = {
+	'&amp;': '&',
+	'&lt;': '<',
+	'&gt;': '>',
+	'&quot;': '"',
+	'&#39;': "'",
+	'&apos;': "'",
+	'&nbsp;': ' '
+};
+
+function decodeEntities(text: string): string {
+	return text.replace(/&(?:amp|lt|gt|quot|#39|apos|nbsp);/gi, entity => ENTITIES[entity.toLowerCase()] ?? entity);
+}
+
+// Rich-text fields (DESCRIPTION, NOTES…) carry real HTML inside the brackets. Block boundaries
+// become line breaks and list items get a bullet so the text keeps its shape once the tags go.
+const LIST_ITEM_RE = /<li[^>]*>/gi;
+const BLOCK_BOUNDARY_RE = /<\/(?:p|li|ul|ol|div|h[1-6]|tr|blockquote|table)\s*>|<br\s*\/?>/gi;
+const TAG_RE = /<[^>]*>/g;
+
+/**
+ * Flatten a bracketed value's markup into readable plain text.
+ *
+ * Regex-based on purpose: the result is rendered as a React text node, never injected as HTML,
+ * so a missed edge case can only show a stray character — it can't execute anything. The
+ * fallback path in RevisionDescription still sanitizes with DOMPurify because that one does
+ * inject HTML.
+ */
+export function htmlToPlainText(value: string): string {
+	if (!value.includes('<')) {
+		return value.trim();
+	}
+
+	return (
+		value
+			.replace(LIST_ITEM_RE, '\n• ')
+			.replace(BLOCK_BOUNDARY_RE, '\n')
+			.replace(TAG_RE, '')
+			.split('\n')
+			.map(line => line.replace(/[ \t]+/g, ' ').trim())
+			// Drop the empty lines the markup leaves behind (e.g. "</p><p> </p><ol>").
+			.filter(line => line !== '' && line !== '•')
+			.join('\n')
+	);
+}
+
+/**
+ * Normalize a bracketed value: strip markup and surface Rally's empty `[]` as null so the UI
+ * can show an explicit placeholder instead of a blank gap.
+ */
+function toValue(raw: string | undefined): string | null {
+	const text = htmlToPlainText((raw ?? '').trim());
+	return text === '' ? null : text;
+}
+
+const EMPTY: ParsedRevisionDescription = { changes: [], structured: false };
+
+/**
+ * Parse a revision description into its individual field changes.
+ * Returns `structured: false` whenever any part of the text is left unexplained.
+ */
+export function parseRevisionDescription(description: string | null | undefined): ParsedRevisionDescription {
+	if (typeof description !== 'string' || description.trim() === '') {
+		return EMPTY;
+	}
+
+	const text = decodeEntities(description).replace(/\s+/g, ' ').trim();
+
+	const changes: RevisionChange[] = [];
+	// Everything the regex did not consume; if what's left is only separators, the parse is total.
+	let leftover = '';
+	let cursor = 0;
+
+	CHANGE_RE.lastIndex = 0;
+	let match: RegExpExecArray | null;
+	while ((match = CHANGE_RE.exec(text)) !== null) {
+		leftover += text.slice(cursor, match.index);
+		cursor = CHANGE_RE.lastIndex;
+
+		const [, field, changedFrom, changedTo, setTo, verb, value] = match;
+		if (verb) {
+			changes.push({
+				field: field.trim(),
+				kind: verb as RevisionChangeKind,
+				from: null,
+				to: toValue(value)
+			});
+		} else if (setTo !== undefined) {
+			changes.push({ field: field.trim(), kind: 'changed', from: null, to: toValue(setTo) });
+		} else {
+			changes.push({ field: field.trim(), kind: 'changed', from: toValue(changedFrom), to: toValue(changedTo) });
+		}
+	}
+	leftover += text.slice(cursor);
+
+	if (changes.length === 0 || leftover.replace(/[,\s]/g, '') !== '') {
+		return { changes: [], structured: false };
+	}
+
+	return { changes, structured: true };
+}

--- a/src/webview/utils/themeColors.ts
+++ b/src/webview/utils/themeColors.ts
@@ -214,14 +214,23 @@ const ENTITY_TYPE_BASE_RGB: Record<RallyEntityType, string> = {
 };
 
 /**
+ * Alpha bump per type, en punts percentuals. L'ambre del sprint és el to més clar de tots
+ * i queda una mica desdibuixat amb l'alpha base, així que puja lleugerament.
+ */
+const ENTITY_TYPE_ALPHA_BOOST: Partial<Record<RallyEntityType, number>> = {
+	sprint: 2
+};
+
+/**
  * Background/border pair for an entity type badge. Both are alpha colours, so they blend
  * into whichever editor background is active — no light/dark branch needed, unlike
  * getScheduleStateColor which paints opaque text.
  */
 export const getEntityTypeColors = (type: RallyEntityType): { background: string; border: string } => {
 	const base = ENTITY_TYPE_BASE_RGB[type];
+	const boost = ENTITY_TYPE_ALPHA_BOOST[type] ?? 0;
 	return {
-		background: `rgb(${base} / 8%)`,
-		border: `rgb(${base} / 13%)`
+		background: `rgb(${base} / ${8 + boost}%)`,
+		border: `rgb(${base} / ${13 + boost}%)`
 	};
 };

--- a/src/webview/utils/themeColors.ts
+++ b/src/webview/utils/themeColors.ts
@@ -4,6 +4,8 @@
  * Reference: https://code.visualstudio.com/api/references/theme-color
  */
 
+import type { RallyEntityType } from '../../types/rally';
+
 export const themeColors = {
 	// ============================================================================
 	// FOREGROUND & BACKGROUND
@@ -197,4 +199,29 @@ export const getScheduleStateColor = (scheduleState?: string): string => {
 		default:
 			return themeColors.descriptionForeground;
 	}
+};
+
+/**
+ * Base RGB triplets of the entity type colour code, one per Rally entity type.
+ * Kept as `'R G B'` strings so the alpha variants below stay a single source of truth.
+ */
+const ENTITY_TYPE_BASE_RGB: Record<RallyEntityType, string> = {
+	defect: '255 42 0', // Vermell
+	userstory: '0 168 84', // Verd
+	task: '0 122 255', // Blau
+	testcase: '160 80 230', // Porpra
+	sprint: '255 168 0' // Ambre
+};
+
+/**
+ * Background/border pair for an entity type badge. Both are alpha colours, so they blend
+ * into whichever editor background is active — no light/dark branch needed, unlike
+ * getScheduleStateColor which paints opaque text.
+ */
+export const getEntityTypeColors = (type: RallyEntityType): { background: string; border: string } => {
+	const base = ENTITY_TYPE_BASE_RGB[type];
+	return {
+		background: `rgb(${base} / 8%)`,
+		border: `rgb(${base} / 13%)`
+	};
 };


### PR DESCRIPTION
Refactors the ScreenHeader component to accept an entityType prop, allowing for the display of an EntityTypeBadge alongside the title. Updates the styling of the badge based on the entity type, improving visual clarity. Additionally, modifies various views to utilize the new entityType feature, ensuring consistent representation of user stories, defects, and sprints across the application.